### PR TITLE
Switch web socket connection to WSS protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,8 @@ Add custom network to your MetaMask:<br>
 
 *Note*: It was confirmed to work on Chrome browser, there were some problems with
 connection to the custom RPC on Firefox.
+
+### ElectrumX Server Connection
+
+Connection to ElectrumX Server is established with `wss` (WebSocket Secure).
+You need to install the server's certificate to your key chain.

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -12,8 +12,8 @@
         },
         "testnetWS": {
             "server": "electrumx-server.tbtc.svc.cluster.local",
-            "port": 50003,
-            "protocol": "ws"
+            "port": 50004,
+            "protocol": "wss"
         }
     }
 }


### PR DESCRIPTION
In this PR we switch connection to electrum server to use WSS protocol.

It requires the installation of the server's certificate.