### PR TITLE
Hide copyable address and change copy

### DIFF
--- a/src/components/Pay.js
+++ b/src/components/Pay.js
@@ -45,7 +45,7 @@ class Pay extends Component {
         </div>
       )
 
-      descriptionText =  'Scan the QR code or click to copy the address below into your wallet'
+      descriptionText =  'Scan the QR code or click to copy the address below into your wallet.'
 
       step = 2
 
@@ -76,7 +76,7 @@ class Pay extends Component {
 
       descriptionText =  (
         <span>
-          Waiting for confirmations. We’ll send you a notification when your tBTC is ready to be minted.
+          Waiting for transaction confirmations. We’ll send you a notification when your tBTC is ready to be minted.
           <p><i>A watched block never boils.</i></p>
         </span>
       )


### PR DESCRIPTION
- Hide copyable address when confirming
- Change copy which makes no sense without QR / address

Current copy: “Waiting for confirmations. We’ll send you a notification when your tBTC is ready to be minted - a watched block never boils.”

Happy to change based on feedback

<img width="863" alt="Screen Shot 2019-08-14 at 1 27 49 PM" src="https://user-images.githubusercontent.com/4722966/63042157-6f68f780-be97-11e9-906f-50a108efe302.png">

