### PR TITLE
Added dependencies cache to CI build steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,8 @@ jobs:
 
       # Run tests.
       - run:
-        name: Run NPM tests
-        command: npm run test:setup && npm run test
+          name: Run NPM tests
+          command: npm run test:setup && npm run test
 
   test_tbtc_helpers:
     executor: docker-node


### PR DESCRIPTION
Added cache to store `node_modules` for `npm install` command.

Based on: https://circleci.com/docs/2.0/caching/