### PR TITLE
Remove Modal from Prove page

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,18 +1,14 @@
 import React, { Component } from 'react'
-import { bindActionCreators } from 'redux'
-import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 
-import { Footer, Header, Modal } from './lib'
-import { openModal } from '../actions'
+import { Footer, Header } from './lib'
 
 class App extends Component {
   render() {
-    const { children, openModal, location } = this.props
+    const { children, location } = this.props
 
     return (
-      <div className="main" onMouseLeave={openModal}>
-        <Modal />
+      <div className="main">
         <div className="app">
           <Header />
           { children }
@@ -23,16 +19,4 @@ class App extends Component {
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators(
-      {
-        openModal
-      },
-      dispatch
-  )
-}
-
-export default connect(
-  () => ({}),
-  mapDispatchToProps
-)(withRouter(App))
+export default withRouter(App)

--- a/src/components/Prove.js
+++ b/src/components/Prove.js
@@ -2,55 +2,10 @@ import React, { Component } from 'react'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 
-import { submitProof, setRenderContent, closeModal } from '../actions'
+import { submitProof } from '../actions'
 import Peanut from './svgs/Peanut'
 
 class Prove extends Component {
-
-  componentDidMount() {
-    const { setRenderContent, closeModal } = this.props
-
-    const renderContent = () => {
-      return (
-        <div className="prove-modal">
-          <div className="modal-left">
-            <div className="title">
-              Wait just a second!
-            </div>
-            <hr />
-            <div className="description">
-              You must submit proof of your deposit on chain or lose your funds.
-            </div>
-            <div className="cta">
-              <a href="/congratulations" onClick={this.handleClickProve}>
-                Submit Proof
-              </a>
-            </div>
-            <div className="cti" onClick={closeModal}>
-              Lose 1 BTC
-            </div>
-          </div>
-          <div className="modal-right">
-            <div className="peanuts">
-              <Peanut width="360"/>
-              <Peanut width="360"/>
-              <Peanut width="360"/>
-            </div>
-          </div>
-        </div>
-      )
-    }
-
-    setRenderContent(renderContent)
-  }
-
-  componentWillUnmount() {
-    const { setRenderContent, closeModal } = this.props
-
-    setRenderContent(null)
-    closeModal()
-  }
-
   handleClickProve = (evt) => {
     evt.preventDefault()
     evt.stopPropagation()
@@ -93,9 +48,7 @@ class Prove extends Component {
 const mapDispatchToProps = (dispatch) => {
   return bindActionCreators(
       {
-        submitProof,
-        setRenderContent,
-        closeModal
+        submitProof
       },
       dispatch
   )


### PR DESCRIPTION
We no longer want to show the modal when leaving the page viewport on the Prove page.

Leaving the generic Modal code in place for potential future use.

Closes #83 