### PR TITLE
Disabled publishing of a new dapp version to keep-dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,10 +82,10 @@ workflows:
     jobs:
       - build_and_test_dapp:
           context: keep-dev
-      - publish_dapp:
-          filters:
-            branches:
-              only: master
-          context: keep-dev
-          requires:
-            - build_and_test_dapp
+      #- publish_dapp:
+      #    filters:
+      #      branches:
+      #        only: master
+      #    context: keep-dev
+      #    requires:
+      #      - build_and_test_dapp


### PR DESCRIPTION
It's a temporary change for the purpose of having a stable demo environment. We'll bring it back later when we figure out how to version-tag our deployments properly.