### PR TITLE
Add temporary plain-text deposit address to final deposit page

### DIFF
--- a/src/components/deposit/Congratulations.js
+++ b/src/components/deposit/Congratulations.js
@@ -43,7 +43,7 @@ const Congratulations = ({ depositAddress }) => (
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    status: state.deposit.depositAddress
+    depositAddress: state.deposit.depositAddress
   }
 }
 


### PR DESCRIPTION
<img width="902" alt="Screen Shot 2019-11-13 at 4 48 20 PM" src="https://user-images.githubusercontent.com/4722966/68807249-81dd0380-0635-11ea-953b-ba10aec98157.png">

This will be replaced by https://github.com/keep-network/tbtc-dapp/issues/105 which is in-flight