### PR TITLE
Updated address of the electrum server for testnet

### DIFF
--- a/src/config/config.json
+++ b/src/config/config.json
@@ -1,7 +1,7 @@
 {
     "electrum": {
         "testnet": {
-            "server": "electrumx-server.tbtc.svc.cluster.local",
+            "server": "electrumx-server.test.tbtc.network",
             "port": 50002,
             "protocol": "ssl"
         },


### PR DESCRIPTION
Updated address of the electrum server we use in the dapp to the one which is publicly exposed.