### PR TITLE
Fix links in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,13 +10,13 @@ toc::[]
 
 The dApp requires artifacts of the contracts deployed to the development environment.
 To fetch the latest artifacts run `npm run setup`. The command will download files
-stored in the Google Cloud. For initial configuration of the `gcloud` please refer 
-to the [instruction](https://github.com/keep-network/keep-core/blob/master/infrastructure/kube/keep-dev/kube-setup.org#first-time-with-this-environment).
+stored in the Google Cloud. For initial configuration of the `gcloud` please refer
+to the https://github.com/keep-network/keep-core/blob/master/infrastructure/kube/keep-dev/kube-setup.org#first-time-with-this-environment[instructions].
 
 === Run
 
 `npm start` runs the app in the development mode.<br>
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Open http://localhost:3000[http://localhost:3000] to view it in the browser.
 
 The page will reload if you make edits. You will also see any lint errors in the console.
 
@@ -45,7 +45,7 @@ To run the Docker image execute:
 docker run -p 8080:80 tbtc-dapp
 ```
 
-This will expose the app under [http://localhost:8080](http://localhost:8080).
+This will expose the app under http://localhost:8080[http://localhost:8080].
 
 == Internal TestNet
 
@@ -54,14 +54,14 @@ Contracts with which the app is interacting are deployed under the following
 addresses:
 
 |===
-| Name           | Address                                    
+| Name           | Address
 
 | `Deposit`        | 0xe94728C7572900d914178ab17D7bbc9af8C543A0
 | `DepositFactory` | 0xE54dDac3bDBe943b4b76343c72C02aF5369b9Aaf
 | `TBTCSystem`     | 0x20c0D2C470D9Afcb3846E694a0D9d6dB5ED11a6A
 | `TBTCConstants`  | 0xC9435e9722509aD5AA7B01eBB2F33bdA453A6E58
 | `TBTCToken`      | 0x5373196E86906312c87cB7A30b9461a946DD5C82
-| `ECDSAKeep`      | deployed via keep factory                 
+| `ECDSAKeep`      | deployed via keep factory
 |===
 
 === MetaMask


### PR DESCRIPTION
Asciidoc [doesn't appear to support Markdown-style links](https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#links).