### PR TITLE
Add nginx config to route paths properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ FROM nginx:1.17-alpine
 
 COPY --from=build /app/build /usr/share/nginx/html
 
+RUN rm /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d
+
 EXPOSE 80
 
 ## Set `daemon off` so the nginx is run in the foreground.

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,11 @@
+server {
+
+  listen 80;
+
+  location / {
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    try_files $uri $uri/ /index.html;
+  }
+}
+


### PR DESCRIPTION
The dApp expects all URLs to render the index.html file, just under a
different URL path. This pulls from work on the Keep Token Dashboard to
achieve that for the tBTC dApp as well.

Shamelessly stolen from @r-czajkowski's work on the Keep staking dApp.