### PR TITLE
Creation Fees: Move deposit creation to use creation fee estimate

### DIFF
--- a/client/src/deposit.js
+++ b/client/src/deposit.js
@@ -71,7 +71,6 @@ export async function getDepositCurrentState(depositAddress) {
 export async function createDeposit() {
   const depositFactory = await DepositFactory.deployed()
   const tbtcSystem = await TBTCSystem.deployed()
-  const tbtcConstants = await TBTCConstants.deployed()
   const tbtcToken = await TBTCToken.deployed()
   const tbtcDepositToken = await TBTCDepositToken.deployed()
   const feeRebateToken = await FeeRebateToken.deployed()
@@ -81,8 +80,8 @@ export async function createDeposit() {
   const _keepSize = '1'
   const _lotSize = satoshisInBtc.times(0.001).toString() // Hard-code 0.001 BTC lot size for now.
 
-  // Get required funder bond value.
-  const funderBond = await tbtcConstants.getFunderBondAmount()
+  // Get deposit creation fee estimate.
+  const creationFeeEstimate = await tbtcSystem.createNewDepositFeeEstimate()
 
   // Create new deposit.
   const result = await depositFactory.createDeposit(
@@ -95,7 +94,7 @@ export async function createDeposit() {
     _keepSize,
     _lotSize,
     {
-      value: funderBond,
+      value: creationFeeEstimate,
     }
   )
 


### PR DESCRIPTION
Funder bonds are no longer a thing; instead, the deposit creator pays a
fee for creating the deposit. This changed a few things in the contract
flow around how we get the amount. The dApp now correctly fetches the
fee estimate.