### PR TITLE
keep-dev/test: SSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ build/
 .DS_Store
 
 client/src/eth/artifacts/*.JSON
+
+# Infrastructure
+.secrets*

--- a/infrastructure/kube/keep-dev/tbtc-dapp-deployment.yaml
+++ b/infrastructure/kube/keep-dev/tbtc-dapp-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: tbtc-dapp
-  namespace: tbtc
+  namespace: default
   labels:
     keel.sh/policy: all
     app: tbtc

--- a/infrastructure/kube/keep-dev/tbtc-dapp-ingress.yaml
+++ b/infrastructure/kube/keep-dev/tbtc-dapp-ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: tbtc-dapp-ingress
+  name: tbtc-dapp
   namespace: default
   annotations:
     kubernetes.io/ingress.allow-http: "false"

--- a/infrastructure/kube/keep-dev/tbtc-dapp-ingress.yaml
+++ b/infrastructure/kube/keep-dev/tbtc-dapp-ingress.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: tbtc-dapp-ingress
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.allow-http: "false"
+spec:
+  tls:
+  - secretName: dapp-dev-tbtc-network
+  backend:
+    serviceName: tbtc-dapp
+    servicePort: 80

--- a/infrastructure/kube/keep-dev/tbtc-dapp-service.yaml
+++ b/infrastructure/kube/keep-dev/tbtc-dapp-service.yaml
@@ -4,7 +4,6 @@ kind: Service
 metadata:
   name: tbtc-dapp
   namespace: default
-  annotations:
   labels:
     app: tbtc
     type: dapp

--- a/infrastructure/kube/keep-dev/tbtc-dapp-service.yaml
+++ b/infrastructure/kube/keep-dev/tbtc-dapp-service.yaml
@@ -3,15 +3,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: tbtc-dapp
-  namespace: tbtc
+  namespace: default
+  annotations:
   labels:
     app: tbtc
     type: dapp
 spec:
+  type: NodePort
   ports:
   - port: 80
     targetPort: 80
-    name: tcp-80
+    name: https-80
   selector:
     app: tbtc
     type: dapp

--- a/infrastructure/kube/keep-dev/tbtc-dapp-service.yaml
+++ b/infrastructure/kube/keep-dev/tbtc-dapp-service.yaml
@@ -13,7 +13,7 @@ spec:
   ports:
   - port: 80
     targetPort: 80
-    name: https-80
+    name: http-80
   selector:
     app: tbtc
     type: dapp

--- a/infrastructure/kube/keep-test/tbtc-dapp-deployment.yaml
+++ b/infrastructure/kube/keep-test/tbtc-dapp-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: tbtc-dapp
-  namespace: tbtc
+  namespace: default
   labels:
     keel.sh/policy: all
     app: tbtc

--- a/infrastructure/kube/keep-test/tbtc-dapp-ingress.yaml
+++ b/infrastructure/kube/keep-test/tbtc-dapp-ingress.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: tbtc-dapp
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.allow-http: "false"
+spec:
+  tls:
+  - secretName: dapp-test-tbtc-network
+  backend:
+    serviceName: tbtc-dapp
+    servicePort: 80

--- a/infrastructure/kube/keep-test/tbtc-dapp-service.yaml
+++ b/infrastructure/kube/keep-test/tbtc-dapp-service.yaml
@@ -1,21 +1,4 @@
 ---
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: tbtc-dapp-http
-  namespace: tbtc
-  labels:
-    app: tbtc
-    type: dapp
-  annotations:
-    kubernetes.io/ingress.class: "gce"
-    kubernetes.io/ingress.allow-http: "true"
-spec:
-  backend:
-    # This assumes service eth-dashboard-http exists and routes to healthy endpoints
-    serviceName: tbtc-dapp-http
-    servicePort: 80
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/infrastructure/kube/keep-test/tbtc-dapp-service.yaml
+++ b/infrastructure/kube/keep-test/tbtc-dapp-service.yaml
@@ -4,7 +4,6 @@ kind: Service
 metadata:
   name: tbtc-dapp
   namespace: default
-  annotations:
   labels:
     app: tbtc
     type: dapp

--- a/infrastructure/kube/keep-test/tbtc-dapp-service.yaml
+++ b/infrastructure/kube/keep-test/tbtc-dapp-service.yaml
@@ -2,17 +2,18 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: tbtc-dapp-http
-  namespace: tbtc
+  name: tbtc-dapp
+  namespace: default
+  annotations:
   labels:
     app: tbtc
     type: dapp
 spec:
   type: NodePort
   ports:
-  - name: tbtc-dapp-http-port
-    port: 80
+  - port: 80
     targetPort: 80
+    name: http-80
   selector:
     app: tbtc
     type: dapp


### PR DESCRIPTION
### Intro

This turned it a bit of an adventure but here we are.  We're working on hardware wallet support for the dapp, as part of that we need a proper SSL connection.

I screwed around with self-signed certs for a bit which works but decided to go ahead and just put  ourselves behind Cloudflare. 

This took upgrading our Cloudflare setup to support custom hostnames, which we've done.  This does mean that we can't use our Google Hosted Zone subdomains for frontends that need secure connections, but I'll be looking into how to handle this via Terraform (in a later step).

### What We Did

#### keep-dev
- Moved the dapp deployment and services back to the `default` namespace.  Not directly related to the issue at hand, but was something in the backlog that made sense to do here.
- Moved the dapp deployment behind an ingress using Cloudflare
- Separated service/ingress configs into separate files.  We've been organizing configuration file scope around configuring a single object type for a given thing.  This is still experimental, may change at some point.

#### keep-test
- Moved the dapp deployment and services back to the `default` namespace.  Not directly related to the issue at hand, but was something in the backlog that made sense to do here.
- Moved the dapp deployment behind an ingress using Cloudflare.

### Testing

Both dev/test deployments have been shipped with the new configs, and aliased in Cloudflare.  Accessed both hosts from Chrome via `https` and `http` (to test redirect) and things look good:

- dapp.dev.tbtc.network

<img width="973" alt="Screen Shot 2020-04-05 at 4 06 13 PM" src="https://user-images.githubusercontent.com/1664226/78508773-66df6d00-7757-11ea-8867-cdb7d86c5143.png">

- dapp.test.tbtc.network

<img width="979" alt="Screen Shot 2020-04-05 at 4 07 00 PM" src="https://user-images.githubusercontent.com/1664226/78508785-84143b80-7757-11ea-8d2d-258772a42432.png">

