### PR TITLE
Upgrade web3 to 1.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3618,25 +3618,25 @@
                     "dependencies": {
                         "abbrev": {
                             "version": "1.1.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
                             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
                             "optional": true
                         },
                         "ansi-regex": {
                             "version": "2.1.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                             "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
                             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                             "optional": true
                         },
                         "are-we-there-yet": {
                             "version": "1.1.5",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
                             "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
                             "optional": true,
                             "requires": {
@@ -3646,13 +3646,13 @@
                         },
                         "balanced-match": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
                             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                             "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
                             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                             "optional": true,
                             "requires": {
@@ -3668,25 +3668,25 @@
                         },
                         "code-point-at": {
                             "version": "1.1.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
                             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                             "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                             "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
                             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                             "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                             "optional": true
                         },
@@ -3701,19 +3701,19 @@
                         },
                         "deep-extend": {
                             "version": "0.6.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
                             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
                             "optional": true
                         },
                         "delegates": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
                             "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                             "optional": true
                         },
                         "detect-libc": {
                             "version": "1.0.3",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
                             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
                             "optional": true
                         },
@@ -3728,13 +3728,13 @@
                         },
                         "fs.realpath": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                             "optional": true
                         },
                         "gauge": {
                             "version": "2.7.4",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
                             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                             "optional": true,
                             "requires": {
@@ -3764,13 +3764,13 @@
                         },
                         "has-unicode": {
                             "version": "2.0.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
                             "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                             "optional": true
                         },
                         "iconv-lite": {
                             "version": "0.4.24",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
                             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                             "optional": true,
                             "requires": {
@@ -3788,7 +3788,7 @@
                         },
                         "inflight": {
                             "version": "1.0.6",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                             "optional": true,
                             "requires": {
@@ -3804,13 +3804,13 @@
                         },
                         "ini": {
                             "version": "1.3.5",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
                             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
                             "optional": true
                         },
                         "is-fullwidth-code-point": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                             "optional": true,
                             "requires": {
@@ -3819,13 +3819,13 @@
                         },
                         "isarray": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                             "optional": true
                         },
                         "minimatch": {
                             "version": "3.0.4",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                             "optional": true,
                             "requires": {
@@ -3929,7 +3929,7 @@
                         },
                         "npmlog": {
                             "version": "4.1.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
                             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
                             "optional": true,
                             "requires": {
@@ -3941,19 +3941,19 @@
                         },
                         "number-is-nan": {
                             "version": "1.0.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                             "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
                             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                             "optional": true
                         },
                         "once": {
                             "version": "1.4.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                             "optional": true,
                             "requires": {
@@ -3962,19 +3962,19 @@
                         },
                         "os-homedir": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
                             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                             "optional": true
                         },
                         "os-tmpdir": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
                             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                             "optional": true
                         },
                         "osenv": {
                             "version": "0.1.5",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
                             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
                             "optional": true,
                             "requires": {
@@ -3984,7 +3984,7 @@
                         },
                         "path-is-absolute": {
                             "version": "1.0.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                             "optional": true
                         },
@@ -3996,7 +3996,7 @@
                         },
                         "rc": {
                             "version": "1.2.8",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
                             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
                             "optional": true,
                             "requires": {
@@ -4040,19 +4040,19 @@
                         },
                         "safe-buffer": {
                             "version": "5.1.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
                             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                             "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
                             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
                             "optional": true
                         },
                         "sax": {
                             "version": "1.2.4",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
                             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
                             "optional": true
                         },
@@ -4064,19 +4064,19 @@
                         },
                         "set-blocking": {
                             "version": "2.0.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
                             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                             "optional": true
                         },
                         "signal-exit": {
                             "version": "3.0.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
                             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                             "optional": true
                         },
                         "string-width": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                             "optional": true,
                             "requires": {
@@ -4087,7 +4087,7 @@
                         },
                         "string_decoder": {
                             "version": "1.1.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                             "optional": true,
                             "requires": {
@@ -4096,7 +4096,7 @@
                         },
                         "strip-ansi": {
                             "version": "3.0.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                             "optional": true,
                             "requires": {
@@ -4105,7 +4105,7 @@
                         },
                         "strip-json-comments": {
                             "version": "2.0.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
                             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                             "optional": true
                         },
@@ -4126,13 +4126,13 @@
                         },
                         "util-deprecate": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                             "optional": true
                         },
                         "wide-align": {
                             "version": "1.1.3",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
                             "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
                             "optional": true,
                             "requires": {
@@ -4141,7 +4141,7 @@
                         },
                         "wrappy": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                             "optional": true
                         },
@@ -8623,25 +8623,25 @@
                     "dependencies": {
                         "abbrev": {
                             "version": "1.1.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
                             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
                             "optional": true
                         },
                         "ansi-regex": {
                             "version": "2.1.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                             "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
                             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                             "optional": true
                         },
                         "are-we-there-yet": {
                             "version": "1.1.5",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
                             "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
                             "optional": true,
                             "requires": {
@@ -8651,13 +8651,13 @@
                         },
                         "balanced-match": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
                             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                             "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
                             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                             "optional": true,
                             "requires": {
@@ -8673,25 +8673,25 @@
                         },
                         "code-point-at": {
                             "version": "1.1.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
                             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                             "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                             "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
                             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                             "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                             "optional": true
                         },
@@ -8706,19 +8706,19 @@
                         },
                         "deep-extend": {
                             "version": "0.6.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
                             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
                             "optional": true
                         },
                         "delegates": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
                             "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                             "optional": true
                         },
                         "detect-libc": {
                             "version": "1.0.3",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
                             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
                             "optional": true
                         },
@@ -8733,13 +8733,13 @@
                         },
                         "fs.realpath": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                             "optional": true
                         },
                         "gauge": {
                             "version": "2.7.4",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
                             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                             "optional": true,
                             "requires": {
@@ -8769,13 +8769,13 @@
                         },
                         "has-unicode": {
                             "version": "2.0.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
                             "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                             "optional": true
                         },
                         "iconv-lite": {
                             "version": "0.4.24",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
                             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                             "optional": true,
                             "requires": {
@@ -8793,7 +8793,7 @@
                         },
                         "inflight": {
                             "version": "1.0.6",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                             "optional": true,
                             "requires": {
@@ -8809,13 +8809,13 @@
                         },
                         "ini": {
                             "version": "1.3.5",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
                             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
                             "optional": true
                         },
                         "is-fullwidth-code-point": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                             "optional": true,
                             "requires": {
@@ -8824,13 +8824,13 @@
                         },
                         "isarray": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                             "optional": true
                         },
                         "minimatch": {
                             "version": "3.0.4",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                             "optional": true,
                             "requires": {
@@ -8934,7 +8934,7 @@
                         },
                         "npmlog": {
                             "version": "4.1.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
                             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
                             "optional": true,
                             "requires": {
@@ -8946,19 +8946,19 @@
                         },
                         "number-is-nan": {
                             "version": "1.0.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                             "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
                             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                             "optional": true
                         },
                         "once": {
                             "version": "1.4.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                             "optional": true,
                             "requires": {
@@ -8967,19 +8967,19 @@
                         },
                         "os-homedir": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
                             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                             "optional": true
                         },
                         "os-tmpdir": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
                             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                             "optional": true
                         },
                         "osenv": {
                             "version": "0.1.5",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
                             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
                             "optional": true,
                             "requires": {
@@ -8989,7 +8989,7 @@
                         },
                         "path-is-absolute": {
                             "version": "1.0.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                             "optional": true
                         },
@@ -9001,7 +9001,7 @@
                         },
                         "rc": {
                             "version": "1.2.8",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
                             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
                             "optional": true,
                             "requires": {
@@ -9045,19 +9045,19 @@
                         },
                         "safe-buffer": {
                             "version": "5.1.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
                             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                             "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
                             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
                             "optional": true
                         },
                         "sax": {
                             "version": "1.2.4",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
                             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
                             "optional": true
                         },
@@ -9069,19 +9069,19 @@
                         },
                         "set-blocking": {
                             "version": "2.0.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
                             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                             "optional": true
                         },
                         "signal-exit": {
                             "version": "3.0.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
                             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                             "optional": true
                         },
                         "string-width": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                             "optional": true,
                             "requires": {
@@ -9092,7 +9092,7 @@
                         },
                         "string_decoder": {
                             "version": "1.1.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                             "optional": true,
                             "requires": {
@@ -9101,7 +9101,7 @@
                         },
                         "strip-ansi": {
                             "version": "3.0.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                             "optional": true,
                             "requires": {
@@ -9110,7 +9110,7 @@
                         },
                         "strip-json-comments": {
                             "version": "2.0.1",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
                             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                             "optional": true
                         },
@@ -9131,13 +9131,13 @@
                         },
                         "util-deprecate": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                             "optional": true
                         },
                         "wide-align": {
                             "version": "1.1.3",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
                             "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
                             "optional": true,
                             "requires": {
@@ -9146,7 +9146,7 @@
                         },
                         "wrappy": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                             "optional": true
                         },
@@ -15832,9 +15832,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.12.29",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.29.tgz",
-                    "integrity": "sha512-yo8Qz0ygADGFptISDj3pOC9wXfln/5pQaN/ysDIzOaAWXt73cNHmtEC8zSO2Y+kse/txmwIAJzkYZ5fooaS5DQ=="
+                    "version": "12.12.34",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.34.tgz",
+                    "integrity": "sha512-BneGN0J9ke24lBRn44hVHNeDlrXRYF+VRp0HbSUNnEZahXGAysHZIqnf/hER6aabdBgzM4YOV4jrR8gj4Zfi0g=="
                 },
                 "aes-js": {
                     "version": "3.0.0",
@@ -15878,9 +15878,9 @@
                     },
                     "dependencies": {
                         "@types/node": {
-                            "version": "10.17.17",
-                            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-                            "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
+                            "version": "10.17.18",
+                            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.18.tgz",
+                            "integrity": "sha512-DQ2hl/Jl3g33KuAUOcMrcAOtsbzb+y/ufakzAdeK9z/H/xsvkpbETZZbPNMIiQuk24f5ZRMCcZIViAwyFIiKmg=="
                         },
                         "elliptic": {
                             "version": "6.3.3",
@@ -15936,9 +15936,9 @@
                     },
                     "dependencies": {
                         "@types/node": {
-                            "version": "10.17.17",
-                            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-                            "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
+                            "version": "10.17.18",
+                            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.18.tgz",
+                            "integrity": "sha512-DQ2hl/Jl3g33KuAUOcMrcAOtsbzb+y/ufakzAdeK9z/H/xsvkpbETZZbPNMIiQuk24f5ZRMCcZIViAwyFIiKmg=="
                         }
                     }
                 },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "tbtc-dapp",
     "version": "0.10.0-pre.0",
     "dependencies": {
+        "@keep-network/tbtc.js": ">0.10.0-pre <0.10.0-rc",
         "bignumber.js": "^9.0.0",
         "classnames": "^2.2.6",
         "history": "^4.9.0",
@@ -15,8 +16,7 @@
         "react-scripts": "3.0.1",
         "redux": "^4.0.4",
         "redux-saga": "^1.0.5",
-        "@keep-network/tbtc.js": ">0.10.0-pre <0.10.0-rc",
-        "web3": "^1.2.0"
+        "web3": "^1.2.6"
     },
     "scripts": {
         "start-js": "sleep 2 && react-scripts start",


### PR DESCRIPTION
web3 v1.2.5 reintroduces support for ABI coding BN/BigNumber types, which was removed in 1.2.0. Lack of support in previous versions is suspected to be the cause of a broken dApp on testnet right now.