### PR TITLE
What a WSS: Move testnet Electrum connection to TLSed WSS

### DIFF
--- a/src/config/config.json
+++ b/src/config/config.json
@@ -12,8 +12,8 @@
         },
         "testnetWS": {
             "server": "electrumx-server.test.tbtc.network",
-            "port": 50003,
-            "protocol": "ws"
+            "port": 8443,
+            "protocol": "wss"
         }
     }
 }


### PR DESCRIPTION
Now that the dApp is being served over an https connection, the
WebSocket connection must also be secure.