### PR TITLE
Circle: Tag you're it!

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,12 +42,12 @@ jobs:
           name: Run Docker build
           command: |
             docker build -t build --target build .
-            docker build -t $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/tbtc-dapp .
+            docker build -t $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/tbtc-dapp:$DOCKER_IMAGE_TAG .
       - run:
           name: Save tbtc-dapp image
           command: |
             mkdir -p /tmp/tbtc-dapp/docker-images/
-            docker save -o /tmp/tbtc-dapp/docker-images/tbtc-dapp.tar $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/tbtc-dapp
+            docker save -o /tmp/tbtc-dapp/docker-images/tbtc-dapp.tar $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/tbtc-dapp:$DOCKER_IMAGE_TAG
       - persist_to_workspace:
           root: /tmp/tbtc-dapp
           paths:
@@ -71,7 +71,7 @@ jobs:
           google-project-id: GOOGLE_PROJECT_ID
           registry-url: $GCR_REGISTRY_URL
           image: tbtc-dapp
-          tag: latest
+          tag: $DOCKER_IMAGE_TAG
 
 workflows:
   version: 2


### PR DESCRIPTION
### Intro

We've been rolling on `latest` image publishes across our keep-dev and keep-test environments for awhile.  While this is fine for our dev environment, it's time we work against properly versioned images for our test/Ropsten environment.

### What we did

Circle builds that run against a git tag generate a Circle env var `CIRCLE_TAG`.  This is perfect for our Docker image tagging needs.  However, the `CIRCLE_TAG` environment variable isn't generated for builds that don't run on a tag.  e.g. all keep-dev / master builds.  We already use environment based Circle contexts to factor out environment specific configs from the Circle config space, so it's a natural fit to handle this in the same way.  The Circle Context environment variable is `DOCKER_IMAGE_TAG`.  For keep-dev it's set to `latest`, and for keep-test it's set to `$CIRCLE_TAG`.