### PR TITLE
keep-prd: Deployment

### DIFF
--- a/infrastructure/kube/keep-prd/tbtc-dapp-deployment.yaml
+++ b/infrastructure/kube/keep-prd/tbtc-dapp-deployment.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: tbtc-dapp
+  namespace: default
+  labels:
+    app: tbtc-dapp
+    type: dapp
+spec:
+  replicas: 6
+  selector:
+    matchLabels:
+      app: tbtc-dapp
+      type: dapp
+  template:
+    metadata:
+      labels:
+        app: tbtc-dapp
+        type: dapp
+    spec:
+      containers:
+      - name: tbtc-dapp
+        image: keepnetwork/tbtc-dapp:v0.16.2
+        ports:
+          - containerPort: 80

--- a/infrastructure/kube/keep-prd/tbtc-dapp-deployment.yaml
+++ b/infrastructure/kube/keep-prd/tbtc-dapp-deployment.yaml
@@ -21,6 +21,6 @@ spec:
     spec:
       containers:
       - name: tbtc-dapp
-        image: keepnetwork/tbtc-dapp:v0.16.2
+        image: keepnetwork/tbtc-dapp:v0.16.3
         ports:
           - containerPort: 80

--- a/infrastructure/kube/keep-prd/tbtc-dapp-ingress.yaml
+++ b/infrastructure/kube/keep-prd/tbtc-dapp-ingress.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: tbtc-dapp
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.allow-http: "false"
+    kubernetes.io/ingress.global-static-ip-name: tbtc-dapp-ingress
+spec:
+  tls:
+  - secretName: tbtc-network-cloudflare-origin-cert
+  backend:
+    serviceName: tbtc-dapp
+    servicePort: 80

--- a/infrastructure/kube/keep-prd/tbtc-dapp-service.yaml
+++ b/infrastructure/kube/keep-prd/tbtc-dapp-service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tbtc-dapp
+  namespace: default
+  labels:
+    app: tbtc-dapp
+    type: dapp
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 80
+    name: http
+  selector:
+    app: tbtc-dapp
+    type: dapp


### PR DESCRIPTION
### Intro

Standard setup for the tbtc-dapp, but in keep-prd.  The only real difference here is that I updated the labels, and am running 6 replicas.

### What We Did

- NodePort Service
- Ingress
- tbtc-dapp Deployment

Label clarification that the app is a "tbtc-dapp" - assuming we may have different types of tbtc-dapps in the future.