### PR TITLE
Release: v0.16.4-rc (Ropsten)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,13 +98,13 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              ignore: /.*/
+              only: /releases\/ropsten\/.*/
       - resolve_latest:
           filters:
             tags:
               only: /^v.*/
             branches:
-              ignore: /.*/
+              only: /releases\/ropsten\/.*/
           context: keep-test
           requires:
             - keep_test_approval
@@ -113,7 +113,7 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              ignore: /.*/
+              only: /releases\/ropsten\/.*/
           context: keep-test
           requires:
             - resolve_latest
@@ -122,7 +122,7 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              ignore: /.*/
+              only: /releases\/ropsten\/.*/
           context: keep-test
           requires:
             - build_dapp

--- a/package-lock.json
+++ b/package-lock.json
@@ -1479,9 +1479,9 @@
             }
         },
         "@keep-network/keep-core": {
-            "version": "0.15.0-pre.4",
-            "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.15.0-pre.4.tgz",
-            "integrity": "sha512-RydiXk8ecxQWeYZdPMHbNfricho9MLHzUruywXdRVxa/lQlVGZOE528YeF1qqAjBOaId9PSV8Mr153RquxtKWQ==",
+            "version": "1.2.3-rc.0",
+            "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.2.3-rc.0.tgz",
+            "integrity": "sha512-0wDqHwpK+DwhOAsY32Uv/C6Gs4Ujgux+TnqB14WutEFfXNJ3dFlnjMZnh2AOVuRLzyY30J4rUwNRW8nfjNjzAA==",
             "requires": {
                 "@openzeppelin/contracts-ethereum-package": "^2.4.0",
                 "@openzeppelin/upgrades": "^2.7.2",
@@ -1496,48 +1496,48 @@
             }
         },
         "@keep-network/keep-ecdsa": {
-            "version": "0.15.0-pre.1",
-            "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.15.0-pre.1.tgz",
-            "integrity": "sha512-wB6JI6Cw6bwMVr57yITAk3vSK1mH3H+YIB1mgzvNbrIMyOlu4xLiQ+OXCJwA7/HLx7i6l5jbMd72XIZmNdXetg==",
+            "version": "1.1.1-rc.2",
+            "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.1.1-rc.2.tgz",
+            "integrity": "sha512-oqWhI1m0pi3L9/fgKCzh72noJyX79VAGKaKxkLCowRSUMUzDMi/3PaBGYXn6gl3iP1vjVQLdhZeG92zDpvGHYg==",
             "requires": {
-                "@keep-network/keep-core": ">0.15.0-pre <0.15.0-rc",
-                "@keep-network/sortition-pools": "0.3.0",
+                "@keep-network/keep-core": ">1.2.3-rc <1.2.3",
+                "@keep-network/sortition-pools": "1.0.0",
                 "@openzeppelin/upgrades": "^2.7.2",
                 "openzeppelin-solidity": "2.3.0",
                 "solidity-bytes-utils": "0.0.7"
             }
         },
         "@keep-network/sortition-pools": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-0.3.0.tgz",
-            "integrity": "sha512-1nr1Wq3wmKYxtkWynB/xMHEYpVAOSCL5XBcHMlsUBGuG9rw+JhbDUNYbbxHNYUZ7sMRq0S0pOrzQVWb5M+ZUig==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.0.0.tgz",
+            "integrity": "sha512-wPOjqQphGtIBTGpGmw8gwBDbvMeq/9wf+HCsD6Vhvd7bcY5lPT/oWFFqhiExhuaLyISwr1fl6Jgm4RkN6Cispg==",
             "requires": {
                 "@openzeppelin/contracts": "^2.4.0"
             }
         },
         "@keep-network/tbtc": {
-            "version": "0.15.0-pre.0",
-            "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-0.15.0-pre.0.tgz",
-            "integrity": "sha512-FPHW0uTXEQ2NX/qDB1Xi3su6xp21rWTD7KmZnFg6ABjbFuzFzrlkEZmBGCrOdVi8vnqgLXCWFVcWAVS4AD4YEQ==",
+            "version": "1.0.1-rc.1",
+            "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.0.1-rc.1.tgz",
+            "integrity": "sha512-MvlTh06BksVAH2H5HKPZMkqfZ4Ysh7dkV8LL4E/ze2KyA/4XqZIs5jToQEypFOf9qTeV0kbTjZlWGKGQyWRfWw==",
             "requires": {
-                "@keep-network/keep-ecdsa": ">0.15.0-pre <0.15.0-rc",
+                "@keep-network/keep-ecdsa": ">1.1.1-rc <1.1.1",
                 "@summa-tx/bitcoin-spv-sol": "^3.0.0",
-                "@summa-tx/relay-sol": "^1.1.0",
+                "@summa-tx/relay-sol": "^2.0.1",
                 "openzeppelin-solidity": "2.3.0"
             }
         },
         "@keep-network/tbtc.js": {
-            "version": "0.15.0-pre.0",
-            "resolved": "https://registry.npmjs.org/@keep-network/tbtc.js/-/tbtc.js-0.15.0-pre.0.tgz",
-            "integrity": "sha512-Z+SYG62tYwTiac4UpO2F/EYLxcPRmdOwGT0ijs3NA1SoZoRwzYJIzTHMAQYuJaeQY4Ha/nDS3puBs+x7abM0nA==",
+            "version": "1.0.1-rc.0",
+            "resolved": "https://registry.npmjs.org/@keep-network/tbtc.js/-/tbtc.js-1.0.1-rc.0.tgz",
+            "integrity": "sha512-9BNKqkLWupDu56aGIfT2ofgXWd5eqipUXf9Mod5C4h5tRVvSOLYfWr2LRBG7Yl7UUShKq/JsPz4c2BlJ5n0+4Q==",
             "requires": {
-                "@keep-network/keep-ecdsa": ">0.15.0-pre <0.15.0-rc",
-                "@keep-network/tbtc": ">0.15.0-pre <0.15.0-rc",
-                "@truffle/contract": "^4.2.2",
+                "@keep-network/keep-ecdsa": ">1.1.1-rc <1.1.1",
+                "@keep-network/tbtc": ">1.0.1-rc <1.0.1",
                 "bcoin": "git+https://github.com/bcoin-org/bcoin.git#8851582",
                 "bcrypto": "^4.1.0",
                 "bufio": "^1.0.6",
-                "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.0"
+                "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.0",
+                "web3-utils": "^1.2.8"
             }
         },
         "@mrmlnc/readdir-enhanced": {
@@ -1555,9 +1555,9 @@
             "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
         },
         "@openzeppelin/contracts": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.5.0.tgz",
-            "integrity": "sha512-t3jm8FrhL9tkkJTofkznTqo/XXdHi21w5yXwalEnaMOp22ZwZ0f/mmKdlgMMLPFa6bSVHbY88mKESwJT/7m5Lg=="
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.5.1.tgz",
+            "integrity": "sha512-qIy6tLx8rtybEsIOAlrM4J/85s2q2nPkDqj/Rx46VakBZ0LwtFhXIVub96LXHczQX0vaqmAueDqNPXtbSXSaYQ=="
         },
         "@openzeppelin/contracts-ethereum-package": {
             "version": "2.5.0",
@@ -1587,9 +1587,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.12.37",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.37.tgz",
-                    "integrity": "sha512-4mXKoDptrXAwZErQHrLzpe0FN/0Wmf5JRniSVIdwUrtDf9wnmEV1teCNLBo/TwuXhkK/bVegoEn/wmb+x0AuPg=="
+                    "version": "12.12.43",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.43.tgz",
+                    "integrity": "sha512-KUyZdkGCnVPuXfsKmDUu2XLui65LZIJ2s0M57noy5e+ixUT2oK33ep7zlvgzI8LElcWqbf8AR+o/3GqAPac2zA=="
                 },
                 "ansi-styles": {
                     "version": "3.2.1",
@@ -1800,9 +1800,9 @@
             "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
         },
         "@solidity-parser/parser": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.5.2.tgz",
-            "integrity": "sha512-uRyvnvVYmgNmTBpWDbBsH/0kPESQhQpEc4KsvMRLVzFJ1o1s0uIv0Y6Y9IB5vI1Dwz2CbS4X/y4Wyw/75cTFnQ=="
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.6.2.tgz",
+            "integrity": "sha512-kUVUvrqttndeprLoXjI5arWHeiP3uh4XODAKbG+ZaWHCVQeelxCbnXBeWxZ2BPHdXgH0xR9dU1b916JhDhbgAA=="
         },
         "@summa-tx/bitcoin-spv-sol": {
             "version": "3.0.0",
@@ -1810,18 +1810,24 @@
             "integrity": "sha512-zyY0o1i5wGdaM8yK6JYlaUzNmZSdsGipXeEQpM7bNDW5d9/CzVOvbP1pOT97wOok2QYJG6f4oU8vf18OWzxkgQ=="
         },
         "@summa-tx/relay-sol": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@summa-tx/relay-sol/-/relay-sol-1.1.0.tgz",
-            "integrity": "sha512-NXWvDRfH0YbEanY8oSK8sEShKI7QO0b3VkJyKRiGJfeGrjenBj13l59gbi+A2/27Q+UD0X+sBQ+BxDjUcInHBw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@summa-tx/relay-sol/-/relay-sol-2.0.1.tgz",
+            "integrity": "sha512-AmE9v6sRW/PwoJiZ2C2HVfrPVVOkf9HNuEOqo4ewfZzbJsKp4AFm/dZ6+IcXWBiY28gdhS70OFSvqb85KKWkNg==",
             "requires": {
-                "@summa-tx/bitcoin-spv-sol": "^2.1.0",
-                "dotenv": "^8.1.0"
+                "@summa-tx/bitcoin-spv-sol": "^2.2.0",
+                "bn.js": "^5.1.1",
+                "dotenv": "^8.2.0"
             },
             "dependencies": {
                 "@summa-tx/bitcoin-spv-sol": {
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/@summa-tx/bitcoin-spv-sol/-/bitcoin-spv-sol-2.2.0.tgz",
                     "integrity": "sha512-HSfxfNldNS4pvZUjLLYqw/wgVrxmIzp67WoRVTxY5SEV7TbOBcn8aYlPCnyLSUX6TeHjMVjAv3inDoIq0zwfCQ=="
+                },
+                "bn.js": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
+                    "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
                 }
             }
         },
@@ -1977,733 +1983,6 @@
             "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
             "requires": {
                 "defer-to-connect": "^1.0.1"
-            }
-        },
-        "@truffle/blockchain-utils": {
-            "version": "0.0.18",
-            "resolved": "https://registry.npmjs.org/@truffle/blockchain-utils/-/blockchain-utils-0.0.18.tgz",
-            "integrity": "sha512-XnRu5p1QO9krJizOeBY5WfzPDvEOmCnOT5u6qF8uN3Kkq9vcH3ZqW4XTuzz9ERZNpZfWb3UJx4PUosgeHLs5vw==",
-            "requires": {
-                "source-map-support": "^0.5.16"
-            }
-        },
-        "@truffle/contract": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.2.2.tgz",
-            "integrity": "sha512-SxwXITIgBYysyMa6/G9zU3yZCzPfHjqDrbPa5QSlS6n3NKMd06mz1L8slV9iZdzqFWe1Rd7U9/bGP+UXmNiScA==",
-            "requires": {
-                "@truffle/blockchain-utils": "^0.0.18",
-                "@truffle/contract-schema": "^3.1.0",
-                "@truffle/error": "^0.0.8",
-                "@truffle/interface-adapter": "^0.4.6",
-                "bignumber.js": "^7.2.1",
-                "ethereum-ens": "^0.8.0",
-                "ethers": "^4.0.0-beta.1",
-                "exorcist": "^1.0.1",
-                "source-map-support": "^0.5.16",
-                "web3": "1.2.1",
-                "web3-core-promievent": "1.2.1",
-                "web3-eth-abi": "1.2.1",
-                "web3-utils": "1.2.1"
-            },
-            "dependencies": {
-                "@types/node": {
-                    "version": "10.17.21",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
-                    "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
-                },
-                "bignumber.js": {
-                    "version": "7.2.1",
-                    "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-                    "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
-                },
-                "eth-lib": {
-                    "version": "0.2.7",
-                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-                    "requires": {
-                        "bn.js": "^4.11.6",
-                        "elliptic": "^6.4.0",
-                        "xhr-request-promise": "^0.1.2"
-                    }
-                },
-                "hash.js": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-                    "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-                    "requires": {
-                        "inherits": "^2.0.3",
-                        "minimalistic-assert": "^1.0.0"
-                    }
-                },
-                "js-sha3": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-                    "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-                },
-                "scrypt-js": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
-                    "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
-                },
-                "semver": {
-                    "version": "6.2.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-                    "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
-                },
-                "uuid": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-                    "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-                },
-                "web3": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.1.tgz",
-                    "integrity": "sha512-nNMzeCK0agb5i/oTWNdQ1aGtwYfXzHottFP2Dz0oGIzavPMGSKyVlr8ibVb1yK5sJBjrWVnTdGaOC2zKDFuFRw==",
-                    "requires": {
-                        "web3-bzz": "1.2.1",
-                        "web3-core": "1.2.1",
-                        "web3-eth": "1.2.1",
-                        "web3-eth-personal": "1.2.1",
-                        "web3-net": "1.2.1",
-                        "web3-shh": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-bzz": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.1.tgz",
-                    "integrity": "sha512-LdOO44TuYbGIPfL4ilkuS89GQovxUpmLz6C1UC7VYVVRILeZS740FVB3j9V4P4FHUk1RenaDfKhcntqgVCHtjw==",
-                    "requires": {
-                        "got": "9.6.0",
-                        "swarm-js": "0.1.39",
-                        "underscore": "1.9.1"
-                    }
-                },
-                "web3-core": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.1.tgz",
-                    "integrity": "sha512-5ODwIqgl8oIg/0+Ai4jsLxkKFWJYE0uLuE1yUKHNVCL4zL6n3rFjRMpKPokd6id6nJCNgeA64KdWQ4XfpnjdMg==",
-                    "requires": {
-                        "web3-core-helpers": "1.2.1",
-                        "web3-core-method": "1.2.1",
-                        "web3-core-requestmanager": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-core-helpers": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.1.tgz",
-                    "integrity": "sha512-Gx3sTEajD5r96bJgfuW377PZVFmXIH4TdqDhgGwd2lZQCcMi+DA4TgxJNJGxn0R3aUVzyyE76j4LBrh412mXrw==",
-                    "requires": {
-                        "underscore": "1.9.1",
-                        "web3-eth-iban": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-core-method": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.1.tgz",
-                    "integrity": "sha512-Ghg2WS23qi6Xj8Od3VCzaImLHseEA7/usvnOItluiIc5cKs00WYWsNy2YRStzU9a2+z8lwQywPYp0nTzR/QXdQ==",
-                    "requires": {
-                        "underscore": "1.9.1",
-                        "web3-core-helpers": "1.2.1",
-                        "web3-core-promievent": "1.2.1",
-                        "web3-core-subscriptions": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-core-promievent": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.1.tgz",
-                    "integrity": "sha512-IVUqgpIKoeOYblwpex4Hye6npM0aMR+kU49VP06secPeN0rHMyhGF0ZGveWBrGvf8WDPI7jhqPBFIC6Jf3Q3zw==",
-                    "requires": {
-                        "any-promise": "1.3.0",
-                        "eventemitter3": "3.1.2"
-                    }
-                },
-                "web3-core-requestmanager": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.1.tgz",
-                    "integrity": "sha512-xfknTC69RfYmLKC+83Jz73IC3/sS2ZLhGtX33D4Q5nQ8yc39ElyAolxr9sJQS8kihOcM6u4J+8gyGMqsLcpIBg==",
-                    "requires": {
-                        "underscore": "1.9.1",
-                        "web3-core-helpers": "1.2.1",
-                        "web3-providers-http": "1.2.1",
-                        "web3-providers-ipc": "1.2.1",
-                        "web3-providers-ws": "1.2.1"
-                    }
-                },
-                "web3-core-subscriptions": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.1.tgz",
-                    "integrity": "sha512-nmOwe3NsB8V8UFsY1r+sW6KjdOS68h8nuh7NzlWxBQT/19QSUGiERRTaZXWu5BYvo1EoZRMxCKyCQpSSXLc08g==",
-                    "requires": {
-                        "eventemitter3": "3.1.2",
-                        "underscore": "1.9.1",
-                        "web3-core-helpers": "1.2.1"
-                    }
-                },
-                "web3-eth": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.1.tgz",
-                    "integrity": "sha512-/2xly4Yry5FW1i+uygPjhfvgUP/MS/Dk+PDqmzp5M88tS86A+j8BzKc23GrlA8sgGs0645cpZK/999LpEF5UdA==",
-                    "requires": {
-                        "underscore": "1.9.1",
-                        "web3-core": "1.2.1",
-                        "web3-core-helpers": "1.2.1",
-                        "web3-core-method": "1.2.1",
-                        "web3-core-subscriptions": "1.2.1",
-                        "web3-eth-abi": "1.2.1",
-                        "web3-eth-accounts": "1.2.1",
-                        "web3-eth-contract": "1.2.1",
-                        "web3-eth-ens": "1.2.1",
-                        "web3-eth-iban": "1.2.1",
-                        "web3-eth-personal": "1.2.1",
-                        "web3-net": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-eth-abi": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.1.tgz",
-                    "integrity": "sha512-jI/KhU2a/DQPZXHjo2GW0myEljzfiKOn+h1qxK1+Y9OQfTcBMxrQJyH5AP89O6l6NZ1QvNdq99ThAxBFoy5L+g==",
-                    "requires": {
-                        "ethers": "4.0.0-beta.3",
-                        "underscore": "1.9.1",
-                        "web3-utils": "1.2.1"
-                    },
-                    "dependencies": {
-                        "elliptic": {
-                            "version": "6.3.3",
-                            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
-                            "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
-                            "requires": {
-                                "bn.js": "^4.4.0",
-                                "brorand": "^1.0.1",
-                                "hash.js": "^1.0.0",
-                                "inherits": "^2.0.1"
-                            }
-                        },
-                        "ethers": {
-                            "version": "4.0.0-beta.3",
-                            "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
-                            "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
-                            "requires": {
-                                "@types/node": "^10.3.2",
-                                "aes-js": "3.0.0",
-                                "bn.js": "^4.4.0",
-                                "elliptic": "6.3.3",
-                                "hash.js": "1.1.3",
-                                "js-sha3": "0.5.7",
-                                "scrypt-js": "2.0.3",
-                                "setimmediate": "1.0.4",
-                                "uuid": "2.0.1",
-                                "xmlhttprequest": "1.8.0"
-                            }
-                        }
-                    }
-                },
-                "web3-eth-accounts": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.1.tgz",
-                    "integrity": "sha512-26I4qq42STQ8IeKUyur3MdQ1NzrzCqPsmzqpux0j6X/XBD7EjZ+Cs0lhGNkSKH5dI3V8CJasnQ5T1mNKeWB7nQ==",
-                    "requires": {
-                        "any-promise": "1.3.0",
-                        "crypto-browserify": "3.12.0",
-                        "eth-lib": "0.2.7",
-                        "scryptsy": "2.1.0",
-                        "semver": "6.2.0",
-                        "underscore": "1.9.1",
-                        "uuid": "3.3.2",
-                        "web3-core": "1.2.1",
-                        "web3-core-helpers": "1.2.1",
-                        "web3-core-method": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    },
-                    "dependencies": {
-                        "uuid": {
-                            "version": "3.3.2",
-                            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-                            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-                        }
-                    }
-                },
-                "web3-eth-contract": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.1.tgz",
-                    "integrity": "sha512-kYFESbQ3boC9bl2rYVghj7O8UKMiuKaiMkxvRH5cEDHil8V7MGEGZNH0slSdoyeftZVlaWSMqkRP/chfnKND0g==",
-                    "requires": {
-                        "underscore": "1.9.1",
-                        "web3-core": "1.2.1",
-                        "web3-core-helpers": "1.2.1",
-                        "web3-core-method": "1.2.1",
-                        "web3-core-promievent": "1.2.1",
-                        "web3-core-subscriptions": "1.2.1",
-                        "web3-eth-abi": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-eth-ens": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.1.tgz",
-                    "integrity": "sha512-lhP1kFhqZr2nnbu3CGIFFrAnNxk2veXpOXBY48Tub37RtobDyHijHgrj+xTh+mFiPokyrapVjpFsbGa+Xzye4Q==",
-                    "requires": {
-                        "eth-ens-namehash": "2.0.8",
-                        "underscore": "1.9.1",
-                        "web3-core": "1.2.1",
-                        "web3-core-helpers": "1.2.1",
-                        "web3-core-promievent": "1.2.1",
-                        "web3-eth-abi": "1.2.1",
-                        "web3-eth-contract": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-eth-iban": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.1.tgz",
-                    "integrity": "sha512-9gkr4QPl1jCU+wkgmZ8EwODVO3ovVj6d6JKMos52ggdT2YCmlfvFVF6wlGLwi0VvNa/p+0BjJzaqxnnG/JewjQ==",
-                    "requires": {
-                        "bn.js": "4.11.8",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-eth-personal": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.1.tgz",
-                    "integrity": "sha512-RNDVSiaSoY4aIp8+Hc7z+X72H7lMb3fmAChuSBADoEc7DsJrY/d0R5qQDK9g9t2BO8oxgLrLNyBP/9ub2Hc6Bg==",
-                    "requires": {
-                        "web3-core": "1.2.1",
-                        "web3-core-helpers": "1.2.1",
-                        "web3-core-method": "1.2.1",
-                        "web3-net": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-net": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.1.tgz",
-                    "integrity": "sha512-Yt1Bs7WgnLESPe0rri/ZoPWzSy55ovioaP35w1KZydrNtQ5Yq4WcrAdhBzcOW7vAkIwrsLQsvA+hrOCy7mNauw==",
-                    "requires": {
-                        "web3-core": "1.2.1",
-                        "web3-core-method": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-providers-http": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.1.tgz",
-                    "integrity": "sha512-BDtVUVolT9b3CAzeGVA/np1hhn7RPUZ6YYGB/sYky+GjeO311Yoq8SRDUSezU92x8yImSC2B+SMReGhd1zL+bQ==",
-                    "requires": {
-                        "web3-core-helpers": "1.2.1",
-                        "xhr2-cookies": "1.1.0"
-                    }
-                },
-                "web3-providers-ipc": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.1.tgz",
-                    "integrity": "sha512-oPEuOCwxVx8L4CPD0TUdnlOUZwGBSRKScCz/Ws2YHdr9Ium+whm+0NLmOZjkjQp5wovQbyBzNa6zJz1noFRvFA==",
-                    "requires": {
-                        "oboe": "2.1.4",
-                        "underscore": "1.9.1",
-                        "web3-core-helpers": "1.2.1"
-                    }
-                },
-                "web3-providers-ws": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.1.tgz",
-                    "integrity": "sha512-oqsQXzu+ejJACVHy864WwIyw+oB21nw/pI65/sD95Zi98+/HQzFfNcIFneF1NC4bVF3VNX4YHTNq2I2o97LAiA==",
-                    "requires": {
-                        "underscore": "1.9.1",
-                        "web3-core-helpers": "1.2.1",
-                        "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
-                    }
-                },
-                "web3-shh": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.1.tgz",
-                    "integrity": "sha512-/3Cl04nza5kuFn25bV3FJWa0s3Vafr5BlT933h26xovQ6HIIz61LmvNQlvX1AhFL+SNJOTcQmK1SM59vcyC8bA==",
-                    "requires": {
-                        "web3-core": "1.2.1",
-                        "web3-core-method": "1.2.1",
-                        "web3-core-subscriptions": "1.2.1",
-                        "web3-net": "1.2.1"
-                    }
-                },
-                "web3-utils": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
-                    "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
-                    "requires": {
-                        "bn.js": "4.11.8",
-                        "eth-lib": "0.2.7",
-                        "ethjs-unit": "0.1.6",
-                        "number-to-bn": "1.7.0",
-                        "randomhex": "0.1.5",
-                        "underscore": "1.9.1",
-                        "utf8": "3.0.0"
-                    }
-                }
-            }
-        },
-        "@truffle/contract-schema": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@truffle/contract-schema/-/contract-schema-3.1.0.tgz",
-            "integrity": "sha512-eCMc1CwAmxIpQDsuGM9rCp4q/6GMcdQLTw3Tzd1qufyuti0vWGQwJbBAgSvfofr9ItXHueGwn7I5lVsIbOVYpQ==",
-            "requires": {
-                "ajv": "^6.10.0",
-                "crypto-js": "^3.1.9-1",
-                "debug": "^4.1.0"
-            }
-        },
-        "@truffle/error": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.8.tgz",
-            "integrity": "sha512-x55rtRuNfRO1azmZ30iR0pf0OJ6flQqbax1hJz+Avk1K5fdmOv5cr22s9qFnwTWnS6Bw0jvJEoR0ITsM7cPKtQ=="
-        },
-        "@truffle/interface-adapter": {
-            "version": "0.4.6",
-            "resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.4.6.tgz",
-            "integrity": "sha512-FZAUb7tx/7VbxpAbo70+K2v22j1O7y4BwhWypRwYpf1YbE2C1OCo/L8zInaW5LfzRd2BEsfb2GjUgbK9VaFrDA==",
-            "requires": {
-                "bn.js": "^4.11.8",
-                "ethers": "^4.0.32",
-                "source-map-support": "^0.5.16",
-                "web3": "1.2.1"
-            },
-            "dependencies": {
-                "@types/node": {
-                    "version": "10.17.21",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
-                    "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
-                },
-                "eth-lib": {
-                    "version": "0.2.7",
-                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-                    "requires": {
-                        "bn.js": "^4.11.6",
-                        "elliptic": "^6.4.0",
-                        "xhr-request-promise": "^0.1.2"
-                    }
-                },
-                "hash.js": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-                    "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-                    "requires": {
-                        "inherits": "^2.0.3",
-                        "minimalistic-assert": "^1.0.0"
-                    }
-                },
-                "js-sha3": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-                    "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-                },
-                "scrypt-js": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
-                    "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
-                },
-                "semver": {
-                    "version": "6.2.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-                    "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
-                },
-                "uuid": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-                    "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-                },
-                "web3": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.1.tgz",
-                    "integrity": "sha512-nNMzeCK0agb5i/oTWNdQ1aGtwYfXzHottFP2Dz0oGIzavPMGSKyVlr8ibVb1yK5sJBjrWVnTdGaOC2zKDFuFRw==",
-                    "requires": {
-                        "web3-bzz": "1.2.1",
-                        "web3-core": "1.2.1",
-                        "web3-eth": "1.2.1",
-                        "web3-eth-personal": "1.2.1",
-                        "web3-net": "1.2.1",
-                        "web3-shh": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-bzz": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.1.tgz",
-                    "integrity": "sha512-LdOO44TuYbGIPfL4ilkuS89GQovxUpmLz6C1UC7VYVVRILeZS740FVB3j9V4P4FHUk1RenaDfKhcntqgVCHtjw==",
-                    "requires": {
-                        "got": "9.6.0",
-                        "swarm-js": "0.1.39",
-                        "underscore": "1.9.1"
-                    }
-                },
-                "web3-core": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.1.tgz",
-                    "integrity": "sha512-5ODwIqgl8oIg/0+Ai4jsLxkKFWJYE0uLuE1yUKHNVCL4zL6n3rFjRMpKPokd6id6nJCNgeA64KdWQ4XfpnjdMg==",
-                    "requires": {
-                        "web3-core-helpers": "1.2.1",
-                        "web3-core-method": "1.2.1",
-                        "web3-core-requestmanager": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-core-helpers": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.1.tgz",
-                    "integrity": "sha512-Gx3sTEajD5r96bJgfuW377PZVFmXIH4TdqDhgGwd2lZQCcMi+DA4TgxJNJGxn0R3aUVzyyE76j4LBrh412mXrw==",
-                    "requires": {
-                        "underscore": "1.9.1",
-                        "web3-eth-iban": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-core-method": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.1.tgz",
-                    "integrity": "sha512-Ghg2WS23qi6Xj8Od3VCzaImLHseEA7/usvnOItluiIc5cKs00WYWsNy2YRStzU9a2+z8lwQywPYp0nTzR/QXdQ==",
-                    "requires": {
-                        "underscore": "1.9.1",
-                        "web3-core-helpers": "1.2.1",
-                        "web3-core-promievent": "1.2.1",
-                        "web3-core-subscriptions": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-core-promievent": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.1.tgz",
-                    "integrity": "sha512-IVUqgpIKoeOYblwpex4Hye6npM0aMR+kU49VP06secPeN0rHMyhGF0ZGveWBrGvf8WDPI7jhqPBFIC6Jf3Q3zw==",
-                    "requires": {
-                        "any-promise": "1.3.0",
-                        "eventemitter3": "3.1.2"
-                    }
-                },
-                "web3-core-requestmanager": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.1.tgz",
-                    "integrity": "sha512-xfknTC69RfYmLKC+83Jz73IC3/sS2ZLhGtX33D4Q5nQ8yc39ElyAolxr9sJQS8kihOcM6u4J+8gyGMqsLcpIBg==",
-                    "requires": {
-                        "underscore": "1.9.1",
-                        "web3-core-helpers": "1.2.1",
-                        "web3-providers-http": "1.2.1",
-                        "web3-providers-ipc": "1.2.1",
-                        "web3-providers-ws": "1.2.1"
-                    }
-                },
-                "web3-core-subscriptions": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.1.tgz",
-                    "integrity": "sha512-nmOwe3NsB8V8UFsY1r+sW6KjdOS68h8nuh7NzlWxBQT/19QSUGiERRTaZXWu5BYvo1EoZRMxCKyCQpSSXLc08g==",
-                    "requires": {
-                        "eventemitter3": "3.1.2",
-                        "underscore": "1.9.1",
-                        "web3-core-helpers": "1.2.1"
-                    }
-                },
-                "web3-eth": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.1.tgz",
-                    "integrity": "sha512-/2xly4Yry5FW1i+uygPjhfvgUP/MS/Dk+PDqmzp5M88tS86A+j8BzKc23GrlA8sgGs0645cpZK/999LpEF5UdA==",
-                    "requires": {
-                        "underscore": "1.9.1",
-                        "web3-core": "1.2.1",
-                        "web3-core-helpers": "1.2.1",
-                        "web3-core-method": "1.2.1",
-                        "web3-core-subscriptions": "1.2.1",
-                        "web3-eth-abi": "1.2.1",
-                        "web3-eth-accounts": "1.2.1",
-                        "web3-eth-contract": "1.2.1",
-                        "web3-eth-ens": "1.2.1",
-                        "web3-eth-iban": "1.2.1",
-                        "web3-eth-personal": "1.2.1",
-                        "web3-net": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-eth-abi": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.1.tgz",
-                    "integrity": "sha512-jI/KhU2a/DQPZXHjo2GW0myEljzfiKOn+h1qxK1+Y9OQfTcBMxrQJyH5AP89O6l6NZ1QvNdq99ThAxBFoy5L+g==",
-                    "requires": {
-                        "ethers": "4.0.0-beta.3",
-                        "underscore": "1.9.1",
-                        "web3-utils": "1.2.1"
-                    },
-                    "dependencies": {
-                        "elliptic": {
-                            "version": "6.3.3",
-                            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
-                            "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
-                            "requires": {
-                                "bn.js": "^4.4.0",
-                                "brorand": "^1.0.1",
-                                "hash.js": "^1.0.0",
-                                "inherits": "^2.0.1"
-                            }
-                        },
-                        "ethers": {
-                            "version": "4.0.0-beta.3",
-                            "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
-                            "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
-                            "requires": {
-                                "@types/node": "^10.3.2",
-                                "aes-js": "3.0.0",
-                                "bn.js": "^4.4.0",
-                                "elliptic": "6.3.3",
-                                "hash.js": "1.1.3",
-                                "js-sha3": "0.5.7",
-                                "scrypt-js": "2.0.3",
-                                "setimmediate": "1.0.4",
-                                "uuid": "2.0.1",
-                                "xmlhttprequest": "1.8.0"
-                            }
-                        }
-                    }
-                },
-                "web3-eth-accounts": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.1.tgz",
-                    "integrity": "sha512-26I4qq42STQ8IeKUyur3MdQ1NzrzCqPsmzqpux0j6X/XBD7EjZ+Cs0lhGNkSKH5dI3V8CJasnQ5T1mNKeWB7nQ==",
-                    "requires": {
-                        "any-promise": "1.3.0",
-                        "crypto-browserify": "3.12.0",
-                        "eth-lib": "0.2.7",
-                        "scryptsy": "2.1.0",
-                        "semver": "6.2.0",
-                        "underscore": "1.9.1",
-                        "uuid": "3.3.2",
-                        "web3-core": "1.2.1",
-                        "web3-core-helpers": "1.2.1",
-                        "web3-core-method": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    },
-                    "dependencies": {
-                        "uuid": {
-                            "version": "3.3.2",
-                            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-                            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-                        }
-                    }
-                },
-                "web3-eth-contract": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.1.tgz",
-                    "integrity": "sha512-kYFESbQ3boC9bl2rYVghj7O8UKMiuKaiMkxvRH5cEDHil8V7MGEGZNH0slSdoyeftZVlaWSMqkRP/chfnKND0g==",
-                    "requires": {
-                        "underscore": "1.9.1",
-                        "web3-core": "1.2.1",
-                        "web3-core-helpers": "1.2.1",
-                        "web3-core-method": "1.2.1",
-                        "web3-core-promievent": "1.2.1",
-                        "web3-core-subscriptions": "1.2.1",
-                        "web3-eth-abi": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-eth-ens": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.1.tgz",
-                    "integrity": "sha512-lhP1kFhqZr2nnbu3CGIFFrAnNxk2veXpOXBY48Tub37RtobDyHijHgrj+xTh+mFiPokyrapVjpFsbGa+Xzye4Q==",
-                    "requires": {
-                        "eth-ens-namehash": "2.0.8",
-                        "underscore": "1.9.1",
-                        "web3-core": "1.2.1",
-                        "web3-core-helpers": "1.2.1",
-                        "web3-core-promievent": "1.2.1",
-                        "web3-eth-abi": "1.2.1",
-                        "web3-eth-contract": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-eth-iban": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.1.tgz",
-                    "integrity": "sha512-9gkr4QPl1jCU+wkgmZ8EwODVO3ovVj6d6JKMos52ggdT2YCmlfvFVF6wlGLwi0VvNa/p+0BjJzaqxnnG/JewjQ==",
-                    "requires": {
-                        "bn.js": "4.11.8",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-eth-personal": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.1.tgz",
-                    "integrity": "sha512-RNDVSiaSoY4aIp8+Hc7z+X72H7lMb3fmAChuSBADoEc7DsJrY/d0R5qQDK9g9t2BO8oxgLrLNyBP/9ub2Hc6Bg==",
-                    "requires": {
-                        "web3-core": "1.2.1",
-                        "web3-core-helpers": "1.2.1",
-                        "web3-core-method": "1.2.1",
-                        "web3-net": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-net": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.1.tgz",
-                    "integrity": "sha512-Yt1Bs7WgnLESPe0rri/ZoPWzSy55ovioaP35w1KZydrNtQ5Yq4WcrAdhBzcOW7vAkIwrsLQsvA+hrOCy7mNauw==",
-                    "requires": {
-                        "web3-core": "1.2.1",
-                        "web3-core-method": "1.2.1",
-                        "web3-utils": "1.2.1"
-                    }
-                },
-                "web3-providers-http": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.1.tgz",
-                    "integrity": "sha512-BDtVUVolT9b3CAzeGVA/np1hhn7RPUZ6YYGB/sYky+GjeO311Yoq8SRDUSezU92x8yImSC2B+SMReGhd1zL+bQ==",
-                    "requires": {
-                        "web3-core-helpers": "1.2.1",
-                        "xhr2-cookies": "1.1.0"
-                    }
-                },
-                "web3-providers-ipc": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.1.tgz",
-                    "integrity": "sha512-oPEuOCwxVx8L4CPD0TUdnlOUZwGBSRKScCz/Ws2YHdr9Ium+whm+0NLmOZjkjQp5wovQbyBzNa6zJz1noFRvFA==",
-                    "requires": {
-                        "oboe": "2.1.4",
-                        "underscore": "1.9.1",
-                        "web3-core-helpers": "1.2.1"
-                    }
-                },
-                "web3-providers-ws": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.1.tgz",
-                    "integrity": "sha512-oqsQXzu+ejJACVHy864WwIyw+oB21nw/pI65/sD95Zi98+/HQzFfNcIFneF1NC4bVF3VNX4YHTNq2I2o97LAiA==",
-                    "requires": {
-                        "underscore": "1.9.1",
-                        "web3-core-helpers": "1.2.1",
-                        "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
-                    }
-                },
-                "web3-shh": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.1.tgz",
-                    "integrity": "sha512-/3Cl04nza5kuFn25bV3FJWa0s3Vafr5BlT933h26xovQ6HIIz61LmvNQlvX1AhFL+SNJOTcQmK1SM59vcyC8bA==",
-                    "requires": {
-                        "web3-core": "1.2.1",
-                        "web3-core-method": "1.2.1",
-                        "web3-core-subscriptions": "1.2.1",
-                        "web3-net": "1.2.1"
-                    }
-                },
-                "web3-utils": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
-                    "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
-                    "requires": {
-                        "bn.js": "4.11.8",
-                        "eth-lib": "0.2.7",
-                        "ethjs-unit": "0.1.6",
-                        "number-to-bn": "1.7.0",
-                        "randomhex": "0.1.5",
-                        "underscore": "1.9.1",
-                        "utf8": "3.0.0"
-                    }
-                }
             }
         },
         "@types/babel__core": {
@@ -4871,25 +4150,25 @@
                     "dependencies": {
                         "abbrev": {
                             "version": "1.1.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
                             "optional": true
                         },
                         "ansi-regex": {
                             "version": "2.1.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                             "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                             "optional": true
                         },
                         "are-we-there-yet": {
                             "version": "1.1.5",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
                             "optional": true,
                             "requires": {
@@ -4899,13 +4178,13 @@
                         },
                         "balanced-match": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                             "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                             "optional": true,
                             "requires": {
@@ -4920,25 +4199,25 @@
                         },
                         "code-point-at": {
                             "version": "1.1.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                             "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                             "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                             "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                             "optional": true
                         },
@@ -4952,19 +4231,19 @@
                         },
                         "deep-extend": {
                             "version": "0.6.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
                             "optional": true
                         },
                         "delegates": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                             "optional": true
                         },
                         "detect-libc": {
                             "version": "1.0.3",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
                             "optional": true
                         },
@@ -4978,13 +4257,13 @@
                         },
                         "fs.realpath": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                             "optional": true
                         },
                         "gauge": {
                             "version": "2.7.4",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                             "optional": true,
                             "requires": {
@@ -5013,13 +4292,13 @@
                         },
                         "has-unicode": {
                             "version": "2.0.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                             "optional": true
                         },
                         "iconv-lite": {
                             "version": "0.4.24",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                             "optional": true,
                             "requires": {
@@ -5036,7 +4315,7 @@
                         },
                         "inflight": {
                             "version": "1.0.6",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                             "optional": true,
                             "requires": {
@@ -5051,13 +4330,13 @@
                         },
                         "ini": {
                             "version": "1.3.5",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
                             "optional": true
                         },
                         "is-fullwidth-code-point": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                             "optional": true,
                             "requires": {
@@ -5066,13 +4345,13 @@
                         },
                         "isarray": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                             "optional": true
                         },
                         "minimatch": {
                             "version": "3.0.4",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                             "optional": true,
                             "requires": {
@@ -5175,7 +4454,7 @@
                         },
                         "npmlog": {
                             "version": "4.1.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
                             "optional": true,
                             "requires": {
@@ -5187,19 +4466,19 @@
                         },
                         "number-is-nan": {
                             "version": "1.0.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                             "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                             "optional": true
                         },
                         "once": {
                             "version": "1.4.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                             "optional": true,
                             "requires": {
@@ -5208,19 +4487,19 @@
                         },
                         "os-homedir": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                             "optional": true
                         },
                         "os-tmpdir": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                             "optional": true
                         },
                         "osenv": {
                             "version": "0.1.5",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
                             "optional": true,
                             "requires": {
@@ -5230,7 +4509,7 @@
                         },
                         "path-is-absolute": {
                             "version": "1.0.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                             "optional": true
                         },
@@ -5241,7 +4520,7 @@
                         },
                         "rc": {
                             "version": "1.2.8",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
                             "optional": true,
                             "requires": {
@@ -5275,19 +4554,19 @@
                         },
                         "safe-buffer": {
                             "version": "5.1.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                             "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
                             "optional": true
                         },
                         "sax": {
                             "version": "1.2.4",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
                             "optional": true
                         },
@@ -5298,19 +4577,19 @@
                         },
                         "set-blocking": {
                             "version": "2.0.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                             "optional": true
                         },
                         "signal-exit": {
                             "version": "3.0.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                             "optional": true
                         },
                         "string-width": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                             "optional": true,
                             "requires": {
@@ -5321,7 +4600,7 @@
                         },
                         "string_decoder": {
                             "version": "1.1.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                             "optional": true,
                             "requires": {
@@ -5330,7 +4609,7 @@
                         },
                         "strip-ansi": {
                             "version": "3.0.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                             "optional": true,
                             "requires": {
@@ -5339,7 +4618,7 @@
                         },
                         "strip-json-comments": {
                             "version": "2.0.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                             "optional": true
                         },
@@ -5359,13 +4638,13 @@
                         },
                         "util-deprecate": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                             "optional": true
                         },
                         "wide-align": {
                             "version": "1.1.3",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
                             "optional": true,
                             "requires": {
@@ -5374,7 +4653,7 @@
                         },
                         "wrappy": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                             "optional": true
                         },
@@ -6739,33 +6018,6 @@
             "from": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.0",
             "requires": {
                 "websocket": "^1.0.29"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                },
-                "websocket": {
-                    "version": "1.0.31",
-                    "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.31.tgz",
-                    "integrity": "sha512-VAouplvGKPiKFDTeCCO65vYHsyay8DqoBSlzIO3fayrfOgU94lQN5a1uWVnFrMLceTJw/+fQXR5PGbUVRaHshQ==",
-                    "requires": {
-                        "debug": "^2.2.0",
-                        "es5-ext": "^0.10.50",
-                        "nan": "^2.14.0",
-                        "typedarray-to-buffer": "^3.1.5",
-                        "yaeti": "^0.0.6"
-                    }
-                }
             }
         },
         "elliptic": {
@@ -7414,26 +6666,6 @@
             "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
             "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
         },
-        "ethereum-ens": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/ethereum-ens/-/ethereum-ens-0.8.0.tgz",
-            "integrity": "sha512-a8cBTF4AWw1Q1Y37V1LSCS9pRY4Mh3f8vCg5cbXCCEJ3eno1hbI/+Ccv9SZLISYpqQhaglP3Bxb/34lS4Qf7Bg==",
-            "requires": {
-                "bluebird": "^3.4.7",
-                "eth-ens-namehash": "^2.0.0",
-                "js-sha3": "^0.5.7",
-                "pako": "^1.0.4",
-                "underscore": "^1.8.3",
-                "web3": "^1.0.0-beta.34"
-            },
-            "dependencies": {
-                "js-sha3": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-                    "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-                }
-            }
-        },
         "ethereumjs-account": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
@@ -7767,39 +6999,6 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
             "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
-        },
-        "exorcist": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/exorcist/-/exorcist-1.0.1.tgz",
-            "integrity": "sha1-eTFuPEiFhFSQ97tAXA5bXbEWfFI=",
-            "requires": {
-                "is-stream": "~1.1.0",
-                "minimist": "0.0.5",
-                "mkdirp": "~0.5.1",
-                "mold-source-map": "~0.4.0"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "0.0.5",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
-                    "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY="
-                },
-                "mkdirp": {
-                    "version": "0.5.5",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-                    "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-                    "requires": {
-                        "minimist": "^1.2.5"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "1.2.5",
-                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-                            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-                        }
-                    }
-                }
-            }
         },
         "expand-brackets": {
             "version": "2.1.4",
@@ -10298,25 +9497,25 @@
                     "dependencies": {
                         "abbrev": {
                             "version": "1.1.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
                             "optional": true
                         },
                         "ansi-regex": {
                             "version": "2.1.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                             "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                             "optional": true
                         },
                         "are-we-there-yet": {
                             "version": "1.1.5",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
                             "optional": true,
                             "requires": {
@@ -10326,13 +9525,13 @@
                         },
                         "balanced-match": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                             "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                             "optional": true,
                             "requires": {
@@ -10347,25 +9546,25 @@
                         },
                         "code-point-at": {
                             "version": "1.1.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                             "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                             "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                             "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                             "optional": true
                         },
@@ -10379,19 +9578,19 @@
                         },
                         "deep-extend": {
                             "version": "0.6.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
                             "optional": true
                         },
                         "delegates": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                             "optional": true
                         },
                         "detect-libc": {
                             "version": "1.0.3",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
                             "optional": true
                         },
@@ -10405,13 +9604,13 @@
                         },
                         "fs.realpath": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                             "optional": true
                         },
                         "gauge": {
                             "version": "2.7.4",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                             "optional": true,
                             "requires": {
@@ -10440,13 +9639,13 @@
                         },
                         "has-unicode": {
                             "version": "2.0.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                             "optional": true
                         },
                         "iconv-lite": {
                             "version": "0.4.24",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                             "optional": true,
                             "requires": {
@@ -10463,7 +9662,7 @@
                         },
                         "inflight": {
                             "version": "1.0.6",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                             "optional": true,
                             "requires": {
@@ -10478,13 +9677,13 @@
                         },
                         "ini": {
                             "version": "1.3.5",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
                             "optional": true
                         },
                         "is-fullwidth-code-point": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                             "optional": true,
                             "requires": {
@@ -10493,13 +9692,13 @@
                         },
                         "isarray": {
                             "version": "1.0.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                             "optional": true
                         },
                         "minimatch": {
                             "version": "3.0.4",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                             "optional": true,
                             "requires": {
@@ -10602,7 +9801,7 @@
                         },
                         "npmlog": {
                             "version": "4.1.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
                             "optional": true,
                             "requires": {
@@ -10614,19 +9813,19 @@
                         },
                         "number-is-nan": {
                             "version": "1.0.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                             "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                             "optional": true
                         },
                         "once": {
                             "version": "1.4.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                             "optional": true,
                             "requires": {
@@ -10635,19 +9834,19 @@
                         },
                         "os-homedir": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                             "optional": true
                         },
                         "os-tmpdir": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                             "optional": true
                         },
                         "osenv": {
                             "version": "0.1.5",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
                             "optional": true,
                             "requires": {
@@ -10657,7 +9856,7 @@
                         },
                         "path-is-absolute": {
                             "version": "1.0.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                             "optional": true
                         },
@@ -10668,7 +9867,7 @@
                         },
                         "rc": {
                             "version": "1.2.8",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
                             "optional": true,
                             "requires": {
@@ -10702,19 +9901,19 @@
                         },
                         "safe-buffer": {
                             "version": "5.1.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                             "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
                             "optional": true
                         },
                         "sax": {
                             "version": "1.2.4",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
                             "optional": true
                         },
@@ -10725,19 +9924,19 @@
                         },
                         "set-blocking": {
                             "version": "2.0.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                             "optional": true
                         },
                         "signal-exit": {
                             "version": "3.0.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                             "optional": true
                         },
                         "string-width": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                             "optional": true,
                             "requires": {
@@ -10748,7 +9947,7 @@
                         },
                         "string_decoder": {
                             "version": "1.1.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                             "optional": true,
                             "requires": {
@@ -10757,7 +9956,7 @@
                         },
                         "strip-ansi": {
                             "version": "3.0.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                             "optional": true,
                             "requires": {
@@ -10766,7 +9965,7 @@
                         },
                         "strip-json-comments": {
                             "version": "2.0.1",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                             "optional": true
                         },
@@ -10786,13 +9985,13 @@
                         },
                         "util-deprecate": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                             "optional": true
                         },
                         "wide-align": {
                             "version": "1.1.3",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
                             "optional": true,
                             "requires": {
@@ -10801,7 +10000,7 @@
                         },
                         "wrappy": {
                             "version": "1.0.2",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                             "optional": true
                         },
@@ -12598,22 +11797,6 @@
             "version": "4.11.0",
             "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.11.0.tgz",
             "integrity": "sha512-Yp4o3/ZA15wsXqJTT+R+9w2AYIkD1i80Lds47wDbuUhOvQvm+O2EfjFZSz0pMgZZSPHRhGxgcd2+GL4+jZMtdw=="
-        },
-        "mold-source-map": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/mold-source-map/-/mold-source-map-0.4.0.tgz",
-            "integrity": "sha1-z2fgsxxHq5uttcnCVlGGISe7gxc=",
-            "requires": {
-                "convert-source-map": "^1.1.0",
-                "through": "~2.2.7"
-            },
-            "dependencies": {
-                "through": {
-                    "version": "2.2.7",
-                    "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
-                    "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0="
-                }
-            }
         },
         "move-concurrently": {
             "version": "1.0.1",
@@ -14825,11 +14008,6 @@
                 "safe-buffer": "^5.1.0"
             }
         },
-        "randomhex": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/randomhex/-/randomhex-0.1.5.tgz",
-            "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU="
-        },
         "range-parser": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -16082,7 +15260,7 @@
             "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
         },
         "scrypt-shim": {
-            "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+            "version": "github:web3-js/scrypt-shim#aafdadda13e660e25e1c525d1f5b2443f5eb1ebb",
             "from": "github:web3-js/scrypt-shim",
             "requires": {
                 "scryptsy": "^2.1.0",
@@ -17548,9 +16726,9 @@
             "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
         },
         "tape": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.2.tgz",
-            "integrity": "sha512-waWwC/OqYVE9TS6r1IynlP2sEdk4Lfo6jazlgkuNkPTHIbuG2BTABIaKdlQWwPeB6Oo4ksZ1j33Yt0NTOAlYMQ==",
+            "version": "4.13.3",
+            "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.3.tgz",
+            "integrity": "sha512-0/Y20PwRIUkQcTCSi4AASs+OANZZwqPKaipGCEwp10dQMipVvSZwUUCi01Y/OklIGyHKFhIcjock+DKnBfLAFw==",
             "requires": {
                 "deep-equal": "~1.1.1",
                 "defined": "~1.0.0",
@@ -17561,12 +16739,22 @@
                 "has": "~1.0.3",
                 "inherits": "~2.0.4",
                 "is-regex": "~1.0.5",
-                "minimist": "~1.2.0",
+                "minimist": "~1.2.5",
                 "object-inspect": "~1.7.0",
-                "resolve": "~1.15.1",
+                "resolve": "~1.17.0",
                 "resumer": "~0.0.0",
                 "string.prototype.trim": "~1.2.1",
                 "through": "~2.3.8"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.17.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+                    "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                }
             }
         },
         "tar": {
@@ -17911,12 +17099,12 @@
             }
         },
         "truffle-flattener": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.4.3.tgz",
-            "integrity": "sha512-r29fkSkV8i9oMW35KbpKR0bP4iPnzIJqlW2S+CL3BjLsxq6YnlMn9+e0BpiJIJPmeXJgeYHQvCGceucpM0Dovg==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.4.4.tgz",
+            "integrity": "sha512-S/WmvubzlUj1mn56wEI6yo1bmPpKDNdEe5rtyVC1C5iNfZWobD/V69pAYI15IBDJrDqUyh+iXgpTkzov50zpQw==",
             "requires": {
                 "@resolver-engine/imports-fs": "^0.2.2",
-                "@solidity-parser/parser": "^0.5.2",
+                "@solidity-parser/parser": "^0.6.0",
                 "find-up": "^2.1.0",
                 "mkdirp": "^1.0.4",
                 "tsort": "0.0.1"
@@ -18832,9 +18020,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "10.17.21",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
-                    "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
+                    "version": "10.17.24",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
+                    "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
                 }
             }
         },
@@ -18852,9 +18040,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.12.37",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.37.tgz",
-                    "integrity": "sha512-4mXKoDptrXAwZErQHrLzpe0FN/0Wmf5JRniSVIdwUrtDf9wnmEV1teCNLBo/TwuXhkK/bVegoEn/wmb+x0AuPg=="
+                    "version": "12.12.43",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.43.tgz",
+                    "integrity": "sha512-KUyZdkGCnVPuXfsKmDUu2XLui65LZIJ2s0M57noy5e+ixUT2oK33ep7zlvgzI8LElcWqbf8AR+o/3GqAPac2zA=="
                 },
                 "eth-lib": {
                     "version": "0.2.7",
@@ -19048,9 +18236,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "10.17.21",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
-                    "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
+                    "version": "10.17.24",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
+                    "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
                 },
                 "elliptic": {
                     "version": "6.3.3",
@@ -19333,9 +18521,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.12.37",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.37.tgz",
-                    "integrity": "sha512-4mXKoDptrXAwZErQHrLzpe0FN/0Wmf5JRniSVIdwUrtDf9wnmEV1teCNLBo/TwuXhkK/bVegoEn/wmb+x0AuPg=="
+                    "version": "12.12.43",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.43.tgz",
+                    "integrity": "sha512-KUyZdkGCnVPuXfsKmDUu2XLui65LZIJ2s0M57noy5e+ixUT2oK33ep7zlvgzI8LElcWqbf8AR+o/3GqAPac2zA=="
                 },
                 "eth-lib": {
                     "version": "0.2.7",
@@ -19907,8 +19095,8 @@
             }
         },
         "websocket": {
-            "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-            "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+            "version": "1.0.29",
+            "resolved": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
             "requires": {
                 "debug": "^2.2.0",
                 "es5-ext": "^0.10.50",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "tbtc-dapp",
-    "version": "0.15.0-pre",
+    "version": "0.16.4-rc",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1479,9 +1479,9 @@
             }
         },
         "@keep-network/keep-core": {
-            "version": "1.2.3-rc.0",
-            "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.2.3-rc.0.tgz",
-            "integrity": "sha512-0wDqHwpK+DwhOAsY32Uv/C6Gs4Ujgux+TnqB14WutEFfXNJ3dFlnjMZnh2AOVuRLzyY30J4rUwNRW8nfjNjzAA==",
+            "version": "1.2.4-rc.1",
+            "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.2.4-rc.1.tgz",
+            "integrity": "sha512-Pda3oitEIcNC9diiNfFOi5SPiK8TNtl/JW8ucOwYMSCHbQJmrxITeJ6PGS5hwMdhf81lToBMYvhwpf3Slv+D7w==",
             "requires": {
                 "@openzeppelin/contracts-ethereum-package": "^2.4.0",
                 "@openzeppelin/upgrades": "^2.7.2",
@@ -1496,11 +1496,11 @@
             }
         },
         "@keep-network/keep-ecdsa": {
-            "version": "1.1.1-rc.2",
-            "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.1.1-rc.2.tgz",
-            "integrity": "sha512-oqWhI1m0pi3L9/fgKCzh72noJyX79VAGKaKxkLCowRSUMUzDMi/3PaBGYXn6gl3iP1vjVQLdhZeG92zDpvGHYg==",
+            "version": "1.1.2-rc.0",
+            "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.1.2-rc.0.tgz",
+            "integrity": "sha512-poPEYr4cf/6AmY3A73BNoHIs0crz/bCmF6+4konrnH3qiLegX+fPU7Kc4KIpa34bNfF0GjG04o06HTT/mFvmjw==",
             "requires": {
-                "@keep-network/keep-core": ">1.2.3-rc <1.2.3",
+                "@keep-network/keep-core": ">1.2.4-rc <1.2.4",
                 "@keep-network/sortition-pools": "1.0.0",
                 "@openzeppelin/upgrades": "^2.7.2",
                 "openzeppelin-solidity": "2.3.0",
@@ -1516,28 +1516,55 @@
             }
         },
         "@keep-network/tbtc": {
-            "version": "1.0.1-rc.1",
-            "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.0.1-rc.1.tgz",
-            "integrity": "sha512-MvlTh06BksVAH2H5HKPZMkqfZ4Ysh7dkV8LL4E/ze2KyA/4XqZIs5jToQEypFOf9qTeV0kbTjZlWGKGQyWRfWw==",
+            "version": "1.0.2-rc.0",
+            "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.0.2-rc.0.tgz",
+            "integrity": "sha512-a1zcj7gxVb/l4FonZC6ZFXAbQcQXkVmWIMIcq4zDX3P0cxbXczTzRd9QVrw4Y6xBvjjJS5IEVHMLwuu60zrGVQ==",
             "requires": {
-                "@keep-network/keep-ecdsa": ">1.1.1-rc <1.1.1",
+                "@keep-network/keep-ecdsa": ">1.1.2-rc <1.1.2",
                 "@summa-tx/bitcoin-spv-sol": "^3.0.0",
                 "@summa-tx/relay-sol": "^2.0.1",
                 "openzeppelin-solidity": "2.3.0"
             }
         },
         "@keep-network/tbtc.js": {
-            "version": "1.0.1-rc.0",
-            "resolved": "https://registry.npmjs.org/@keep-network/tbtc.js/-/tbtc.js-1.0.1-rc.0.tgz",
-            "integrity": "sha512-9BNKqkLWupDu56aGIfT2ofgXWd5eqipUXf9Mod5C4h5tRVvSOLYfWr2LRBG7Yl7UUShKq/JsPz4c2BlJ5n0+4Q==",
+            "version": "1.0.2-rc.0",
+            "resolved": "https://registry.npmjs.org/@keep-network/tbtc.js/-/tbtc.js-1.0.2-rc.0.tgz",
+            "integrity": "sha512-KA7z9tVko9wHkSFsB7lLVszykm82a9O6MBo4j1x8xhDqOOia+o4LhWrib5owASsUkN/1pjYSgolZBjvRvFOfVA==",
             "requires": {
-                "@keep-network/keep-ecdsa": ">1.1.1-rc <1.1.1",
-                "@keep-network/tbtc": ">1.0.1-rc <1.0.1",
+                "@keep-network/keep-ecdsa": ">1.1.2-rc <1.1.2",
+                "@keep-network/tbtc": ">1.0.2-rc <1.0.2",
                 "bcoin": "git+https://github.com/bcoin-org/bcoin.git#8851582",
                 "bcrypto": "^4.1.0",
-                "bufio": "^1.0.6",
+                "bufio": "^1.0.7",
                 "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.0",
-                "web3-utils": "^1.2.8"
+                "web3-utils": "^1.2.9"
+            },
+            "dependencies": {
+                "eth-lib": {
+                    "version": "0.2.7",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "requires": {
+                        "bn.js": "^4.11.6",
+                        "elliptic": "^6.4.0",
+                        "xhr-request-promise": "^0.1.2"
+                    }
+                },
+                "web3-utils": {
+                    "version": "1.2.9",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
+                    "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "eth-lib": "0.2.7",
+                        "ethereum-bloom-filters": "^1.0.6",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randombytes": "^2.1.0",
+                        "underscore": "1.9.1",
+                        "utf8": "3.0.0"
+                    }
+                }
             }
         },
         "@mrmlnc/readdir-enhanced": {
@@ -1587,9 +1614,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.12.43",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.43.tgz",
-                    "integrity": "sha512-KUyZdkGCnVPuXfsKmDUu2XLui65LZIJ2s0M57noy5e+ixUT2oK33ep7zlvgzI8LElcWqbf8AR+o/3GqAPac2zA=="
+                    "version": "12.12.47",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
+                    "integrity": "sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A=="
                 },
                 "ansi-styles": {
                     "version": "3.2.1",
@@ -1805,9 +1832,9 @@
             "integrity": "sha512-kUVUvrqttndeprLoXjI5arWHeiP3uh4XODAKbG+ZaWHCVQeelxCbnXBeWxZ2BPHdXgH0xR9dU1b916JhDhbgAA=="
         },
         "@summa-tx/bitcoin-spv-sol": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@summa-tx/bitcoin-spv-sol/-/bitcoin-spv-sol-3.0.0.tgz",
-            "integrity": "sha512-zyY0o1i5wGdaM8yK6JYlaUzNmZSdsGipXeEQpM7bNDW5d9/CzVOvbP1pOT97wOok2QYJG6f4oU8vf18OWzxkgQ=="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@summa-tx/bitcoin-spv-sol/-/bitcoin-spv-sol-3.1.0.tgz",
+            "integrity": "sha512-YIwxTNCTIsL+qgzcMhzQk9f0A7yQ6dimlLj4i3gGhWrnqBIg3ljBxJ/aj9JRQyIdNDoCPmqS2s8ZZIdyM+vaGQ=="
         },
         "@summa-tx/relay-sol": {
             "version": "2.0.1",
@@ -3428,9 +3455,9 @@
             }
         },
         "binet": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/binet/-/binet-0.3.5.tgz",
-            "integrity": "sha512-suogkqXrt63Z76ABvwJjI28w+LWrRE53nwItDPz1VwNjHEuh1+rxudGYtoewFmMhkJ9pW/VGGnjoxP+AGzHgLQ==",
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/binet/-/binet-0.3.6.tgz",
+            "integrity": "sha512-6pm+Gc3uNiiJZEv0k8JDWqQlo9ki/o9UNAkLmr0EGm7hI5MboOJVIOlO1nw3YuDkLHWN78OPsaC4JhRkn2jMLw==",
             "requires": {
                 "bs32": "~0.1.5",
                 "bsert": "~0.0.10"
@@ -3466,9 +3493,9 @@
             }
         },
         "blgr": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.1.7.tgz",
-            "integrity": "sha512-+jSaU2jnYqF+ec9e8nzjfjU7QhZIntkDNG8/AEwoxW7J3mmwvmUfAI5lm9BFYs1OzT+1UgIZTFHa2qWjTBURfw==",
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.1.8.tgz",
+            "integrity": "sha512-9AvDK+lc92q//63S8cHtkaB060YOZqoqd0DkMwn35mR1SrcY0FXnCHePHZFx6Oe1d/6wj8Lw7mKEGoShCUf3Yw==",
             "requires": {
                 "bsert": "~0.0.10"
             }
@@ -3862,9 +3889,9 @@
             "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
         },
         "bufio": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.6.tgz",
-            "integrity": "sha512-mjYZFRHmI9bk3Oeexu0rWjHFY+w6hGLabdmwSFzq+EFr4MHHsNOYduDVdYl71NG5pTPL7GGzUCMk9cYuV34/Qw=="
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
+            "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A=="
         },
         "builtin-status-codes": {
             "version": "3.0.0",
@@ -8364,9 +8391,9 @@
             "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
         },
         "immediate": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-            "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+            "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
         },
         "immer": {
             "version": "1.10.0",
@@ -18020,9 +18047,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "10.17.24",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
-                    "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
+                    "version": "10.17.26",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+                    "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
                 }
             }
         },
@@ -18040,9 +18067,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.12.43",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.43.tgz",
-                    "integrity": "sha512-KUyZdkGCnVPuXfsKmDUu2XLui65LZIJ2s0M57noy5e+ixUT2oK33ep7zlvgzI8LElcWqbf8AR+o/3GqAPac2zA=="
+                    "version": "12.12.47",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
+                    "integrity": "sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A=="
                 },
                 "eth-lib": {
                     "version": "0.2.7",
@@ -18236,9 +18263,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "10.17.24",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
-                    "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
+                    "version": "10.17.26",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+                    "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
                 },
                 "elliptic": {
                     "version": "6.3.3",
@@ -18262,9 +18289,9 @@
                     },
                     "dependencies": {
                         "elliptic": {
-                            "version": "6.5.2",
-                            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-                            "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+                            "version": "6.5.3",
+                            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+                            "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
                             "requires": {
                                 "bn.js": "^4.4.0",
                                 "brorand": "^1.0.1",
@@ -18521,9 +18548,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.12.43",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.43.tgz",
-                    "integrity": "sha512-KUyZdkGCnVPuXfsKmDUu2XLui65LZIJ2s0M57noy5e+ixUT2oK33ep7zlvgzI8LElcWqbf8AR+o/3GqAPac2zA=="
+                    "version": "12.12.47",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
+                    "integrity": "sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A=="
                 },
                 "eth-lib": {
                     "version": "0.2.7",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "tbtc-dapp",
     "version": "0.16.4-rc",
     "dependencies": {
-        "@keep-network/tbtc.js": ">1.0.2-rc <1.0.2",
+        "@keep-network/tbtc.js": ">0.15.0-rc <0.15.0",
         "@web3-react/core": "^6.0.7",
         "@web3-react/injected-connector": "^6.0.7",
         "bignumber.js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "tbtc-dapp",
-    "version": "0.15.0-pre",
+    "version": "0.16.4-rc",
     "dependencies": {
-        "@keep-network/tbtc.js": ">1.0.1-rc <1.0.1",
+        "@keep-network/tbtc.js": ">1.0.2-rc <1.0.2",
         "@web3-react/core": "^6.0.7",
         "@web3-react/injected-connector": "^6.0.7",
         "bignumber.js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "tbtc-dapp",
     "version": "0.15.0-pre",
     "dependencies": {
-        "@keep-network/tbtc.js": ">0.15.0-pre <0.15.0-rc",
+        "@keep-network/tbtc.js": ">1.0.1-rc <1.0.1",
         "@web3-react/core": "^6.0.7",
         "@web3-react/injected-connector": "^6.0.7",
         "bignumber.js": "^9.0.0",

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -161,7 +161,7 @@ export function* requestADeposit() {
     /** @type {Deposit} */
     let deposit
     try {
-        deposit = yield call([tbtc.Deposit, tbtc.Deposit.withSatoshiLotSize], new BN(100000))
+        deposit = yield call([tbtc.Deposit, tbtc.Deposit.withSatoshiLotSize], new BN(1000000))
     } catch (err) {
         if (err.message.includes(METAMASK_TX_DENIED_ERROR)) return
         throw err


### PR DESCRIPTION
### Intro 

Here's a collection of changes to facilitate deploying an updated tbtc-dapp to the keep-test environment.

### Build Job

https://app.circleci.com/pipelines/github/keep-network/tbtc-dapp/720/workflows/a52db57d-7993-4ba5-8da1-6caa2c5f3a21

### Tasks

- [X]  Bump tbtc-dapp to v0.16.4-rc
- [X] Bump tbtc.js dependency to v1.0.2-rc
- [X] Update Circle config to allow for keep-test workflow to trigger on push to branches with  `/releases`
- [X] Deploy tbtc-dapp v 0.16.4-rc