### PR TITLE
Enable additional urls for better restarts

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+// Fix react-scripts warnings
+3715e662fcd70598a39cf3a9fd120b04ee461737

--- a/package-lock.json
+++ b/package-lock.json
@@ -15368,6 +15368,11 @@
                 "symbol-observable": "^1.2.0"
             }
         },
+        "redux-devtools-extension": {
+            "version": "2.13.8",
+            "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
+            "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
+        },
         "redux-saga": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "react-router-dom": "^5.1.2",
         "react-scripts": "3.0.1",
         "redux": "^4.0.4",
+        "redux-devtools-extension": "^2.13.8",
         "redux-saga": "^1.0.5",
         "web3": "^1.2.6",
         "web3-utils": "^1.2.8"

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -34,11 +34,18 @@ export function restoreRedemptionState(depositAddress) {
 
 // Deposit
 export const REQUEST_A_DEPOSIT = 'REQUEST_A_DEPOSIT'
+export const GET_BITCOIN_ADDRESS = 'GET_BITCOIN_ADDRESS'
 export const AUTO_SUBMIT_DEPOSIT_PROOF = 'AUTO_SUBMIT_DEPOSIT_PROOF'
 
 export function requestADeposit() {
     return {
         type: REQUEST_A_DEPOSIT,
+    }
+}
+
+export function getBitcoinAddress() {
+    return {
+        type: GET_BITCOIN_ADDRESS,
     }
 }
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -58,6 +58,7 @@ export function autoSubmitDepositProof() {
 // Redemption
 export const SAVE_ADDRESSES = 'SAVE_ADDRESSES'
 export const REQUEST_REDEMPTION = 'REQUEST_REDEMPTION'
+export const RESUME_REDEMPTION = 'RESUME_REDEMPTION'
 
 export function saveAddresses({ btcAddress, depositAddress }) {
     return {
@@ -72,6 +73,12 @@ export function saveAddresses({ btcAddress, depositAddress }) {
 export function requestRedemption() {
     return {
         type: REQUEST_REDEMPTION,
+    }
+}
+
+export function resumeRedemption() {
+    return {
+        type: RESUME_REDEMPTION
     }
 }
 

--- a/src/components/deposit/Confirming.js
+++ b/src/components/deposit/Confirming.js
@@ -1,0 +1,68 @@
+import React, { useEffect } from 'react'
+import { bindActionCreators } from 'redux'
+import { connect } from 'react-redux'
+
+import { autoSubmitDepositProof } from '../../actions'
+import StatusIndicator from '../svgs/StatusIndicator'
+
+import { BitcoinHelpers } from '@keep-network/tbtc.js'
+
+import BigNumber from "bignumber.js"
+BigNumber.set({ DECIMAL_PLACES: 8 })
+
+const Confirming = ({ autoSubmitDepositProof, signerFeeInSatoshis }) => {
+  useEffect(() => {
+    autoSubmitDepositProof()
+  }, [autoSubmitDepositProof])
+
+  const signerFee = (new BigNumber(signerFeeInSatoshis.toString()))
+    .div(BitcoinHelpers.satoshisPerBtc.toString()).toString()
+
+  return (
+    <div className="pay pay-confirming">
+      <div className="page-top">
+        <StatusIndicator pulse />
+      </div>
+      <div className="page-body">
+        <div className="step">
+          Step 3/5
+        </div>
+        <div className="title">
+          Confirming...
+        </div>
+        <hr />
+        <div className="description">
+          <div>
+            Waiting for transaction confirmations. We’ll send you a notification
+            when your TBTC is ready to be minted.
+            <p><i>A watched block never boils.</i></p>
+          </div>
+          <div className="custodial-fee">
+            <span className="custodial-fee-label">Signer Fee: </span>
+            {signerFee} BTC*
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const mapStateToProps = (state, ownProps) => {
+  return {
+    signerFeeInSatoshis: state.deposit.signerFeeInSatoshis,
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return bindActionCreators(
+  {
+    autoSubmitDepositProof
+  },
+  dispatch
+  )
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Confirming)

--- a/src/components/deposit/Confirming.js
+++ b/src/components/deposit/Confirming.js
@@ -10,10 +10,16 @@ import { BitcoinHelpers } from '@keep-network/tbtc.js'
 import BigNumber from "bignumber.js"
 BigNumber.set({ DECIMAL_PLACES: 8 })
 
-const Confirming = ({ autoSubmitDepositProof, signerFeeInSatoshis }) => {
+const Confirming = ({
+  autoSubmitDepositProof,
+  didSubmitDepositProof,
+  signerFeeInSatoshis
+}) => {
   useEffect(() => {
-    autoSubmitDepositProof()
-  }, [autoSubmitDepositProof])
+    if (!didSubmitDepositProof) {
+      autoSubmitDepositProof()
+    }
+  }, [autoSubmitDepositProof, didSubmitDepositProof])
 
   const signerFee = (new BigNumber(signerFeeInSatoshis.toString()))
     .div(BitcoinHelpers.satoshisPerBtc.toString()).toString()
@@ -50,6 +56,7 @@ const Confirming = ({ autoSubmitDepositProof, signerFeeInSatoshis }) => {
 const mapStateToProps = (state, ownProps) => {
   return {
     signerFeeInSatoshis: state.deposit.signerFeeInSatoshis,
+    didSubmitDepositProof: state.deposit.didSubmitDepositProof,
   }
 }
 

--- a/src/components/deposit/Confirming.js
+++ b/src/components/deposit/Confirming.js
@@ -33,8 +33,8 @@ const Confirming = ({ autoSubmitDepositProof, signerFeeInSatoshis }) => {
         <hr />
         <div className="description">
           <div>
-            Waiting for transaction confirmations. We’ll send you a notification
-            when your TBTC is ready to be minted.
+            Waiting for transaction confirmations. We’ll send you a browser
+            notification when your TBTC is ready to be minted.
             <p><i>A watched block never boils.</i></p>
           </div>
           <div className="custodial-fee">

--- a/src/components/deposit/GetAddress.js
+++ b/src/components/deposit/GetAddress.js
@@ -6,13 +6,16 @@ import StatusIndicator from '../svgs/StatusIndicator'
 import { getBitcoinAddress } from '../../actions'
 
 const GetAddress = ({ status, getBitcoinAddress }) => {
+  useEffect(() => {
+    getBitcoinAddress()
+  }, [getBitcoinAddress])
+
   const [statusText, setStatusText] = useState('Generating BTC address...')
   useEffect(() => {
     if (status === 3) {
       setStatusText('Fetching BTC address...')
     }
-    getBitcoinAddress()
-  }, [status, getBitcoinAddress])
+  }, [status])
 
   return (
     <div className="invoice">

--- a/src/components/deposit/GetAddress.js
+++ b/src/components/deposit/GetAddress.js
@@ -1,1 +1,43 @@
-export default () => {}
+import React, { useState, useEffect } from 'react'
+import { connect } from 'react-redux'
+
+import StatusIndicator from '../svgs/StatusIndicator'
+
+const GetAddress = ({ status }) => {
+  const [statusText, setStatusText] = useState('Generating BTC address...')
+  useEffect(() => {
+    if (status === 3) {
+      setStatusText('Fetching BTC address...')
+    }
+  }, [status])
+
+  return (
+    <div className="invoice">
+      <div className="page-top">
+        <StatusIndicator pulse />
+      </div>
+      <div className="page-body">
+        <div className="step">
+          Step 2/5
+        </div>
+        <div className="title">
+          Initiating deposit
+        </div>
+        <hr />
+        <div className="description">
+          {statusText}
+        </div>
+      </div>
+    </div >
+  )
+}
+
+const mapStateToProps = (state, ownProps) => {
+  return {
+    status: state.deposit.invoiceStatus
+  }
+}
+
+export default connect(
+  mapStateToProps,
+)(GetAddress)

--- a/src/components/deposit/GetAddress.js
+++ b/src/components/deposit/GetAddress.js
@@ -1,15 +1,18 @@
 import React, { useState, useEffect } from 'react'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 
 import StatusIndicator from '../svgs/StatusIndicator'
+import { getBitcoinAddress } from '../../actions'
 
-const GetAddress = ({ status }) => {
+const GetAddress = ({ status, getBitcoinAddress }) => {
   const [statusText, setStatusText] = useState('Generating BTC address...')
   useEffect(() => {
     if (status === 3) {
       setStatusText('Fetching BTC address...')
     }
-  }, [status])
+    getBitcoinAddress()
+  }, [status, getBitcoinAddress])
 
   return (
     <div className="invoice">
@@ -38,6 +41,16 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
+const mapDispatchToProps = (dispatch) => {
+  return bindActionCreators(
+  {
+    getBitcoinAddress
+  },
+  dispatch
+  )
+}
+
 export default connect(
   mapStateToProps,
+  mapDispatchToProps
 )(GetAddress)

--- a/src/components/deposit/Invoice.js
+++ b/src/components/deposit/Invoice.js
@@ -1,56 +1,34 @@
-import React, { Component } from 'react'
+import React, { useEffect } from 'react'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 
 import { requestADeposit } from '../../actions'
 import StatusIndicator from '../svgs/StatusIndicator'
 
-class Invoice extends Component {
-
-  componentDidMount() {
-    const { requestADeposit } = this.props
-
+const Invoice = ({ requestADeposit }) => {
+  useEffect(() => {
     requestADeposit()
-  }
+  }, [requestADeposit])
 
-  render() {
-    const { status } = this.props
-    let statusText
-
-    if(status === 1) {
-      statusText = 'Initiating...'
-    } else if(status === 2) {
-      statusText = 'Generating BTC address...'
-    } else if(status === 3) {
-      statusText = 'Fetching BTC address...'
-    }
-
-    return (
-      <div className="invoice">
-        <div className="page-top">
-          <StatusIndicator pulse />
+  return (
+    <div className="invoice">
+      <div className="page-top">
+        <StatusIndicator pulse />
+      </div>
+      <div className="page-body">
+        <div className="step">
+          Step 2/5
         </div>
-        <div className="page-body">
-          <div className="step">
-            Step 2/5
-          </div>
-          <div className="title">
-            Initiating deposit
-          </div>
-          <hr />
-          <div className="description">
-            {statusText}
-          </div>
+        <div className="title">
+          Initiating deposit
         </div>
-      </div >
-    )
-  }
-}
-
-const mapStateToProps = (state, ownProps) => {
-  return {
-    status: state.deposit.invoiceStatus
-  }
+        <hr />
+        <div className="description">
+          Initiating...
+        </div>
+      </div>
+    </div >
+  )
 }
 
 const mapDispatchToProps = (dispatch) => {
@@ -63,6 +41,6 @@ const mapDispatchToProps = (dispatch) => {
 }
 
 export default connect(
-  mapStateToProps,
+  null,
   mapDispatchToProps
 )(Invoice)

--- a/src/components/deposit/Pay.js
+++ b/src/components/deposit/Pay.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux'
 
 import { autoSubmitDepositProof } from '../../actions'
 import QRCode from 'qrcode.react'
-import StatusIndicator from '../svgs/StatusIndicator'
 import { useParams } from "react-router-dom"
 
 import { BitcoinHelpers } from '@keep-network/tbtc.js'
@@ -39,94 +38,54 @@ class PayComponent extends Component {
   }
 
   render() {
-    const { btcAddress, btcConfirming, lotInSatoshis, signerFeeInSatoshis } = this.props
+    const { btcAddress, lotInSatoshis, signerFeeInSatoshis } = this.props
     const lotInBtc = (new BigNumber(lotInSatoshis.toString())).div(BitcoinHelpers.satoshisPerBtc.toString())
     const signerFeeInBtc = (new BigNumber(signerFeeInSatoshis.toString())).div(BitcoinHelpers.satoshisPerBtc.toString())
 
     const { copied } = this.state
-    let renderTop, renderTitle, renderCopyAddress, descriptionText, step;
 
     const btcAmount = lotInBtc.toString()
     const signerFee = signerFeeInBtc.toString()
     const btcURL =
       `bitcoin:${btcAddress}?amount=${btcAmount}&label=Single-Use+tBTC+Deposit+Wallet`
 
-    if (!btcConfirming) {
-      renderTop = (
-        <div className="qr-code">
-          <QRCode
-            value={btcURL}
-            renderAs="svg"
-            size={225} />
-        </div>
-      )
-
-      renderTitle = (
-        <div className="title">
-          Pay: {btcAmount} BTC
-        </div>
-      )
-
-      descriptionText =  'Scan the QR code or click to copy the address below into your wallet.'
-
-      step = 2
-
-      renderCopyAddress = (
-        <div className="copy-address">
-          <div className="address" onClick={this.copyAddress}>
-            {btcAddress}
-          </div>
-          {
-            copied
-            ? <div className="copied">Copied!</div>
-            : ''
-          }
-        </div>
-      )
-    } else {
-      renderTop = (
-        <StatusIndicator pulse />
-      )
-
-      renderTitle = (
-        <div className="title">
-          Confirming...
-        </div>
-      )
-
-      descriptionText =  (
-        <span>
-          Waiting for transaction confirmations. We’ll send you a notification when your TBTC is ready to be minted.
-          <p><i>A watched block never boils.</i></p>
-        </span>
-      )
-
-      step = 3
-
-      renderCopyAddress = ''
-    }
-
     return (
       <div className="pay">
         <div className="page-top">
-          {renderTop}
+          <div className="qr-code">
+            <QRCode
+              value={btcURL}
+              renderAs="svg"
+              size={225} />
+          </div>
         </div>
         <div className="page-body">
           <div className="step">
-            Step {step}/5
+            Step 2/5
           </div>
-          {renderTitle}
+          <div className="title">
+            Pay: {btcAmount} BTC
+          </div>
           <hr />
           <div className="description">
             <div>
-              {descriptionText}
+              Scan the QR code or click to copy the address below into your wallet.
             </div>
             <div className="custodial-fee">
               <span className="custodial-fee-label">Signer Fee: </span>
               {signerFee} BTC*
             </div>
           </div>
-          { renderCopyAddress }
+          <div className="copy-address">
+            <div className="address" onClick={this.copyAddress}>
+              {btcAddress}
+            </div>
+            {
+              copied
+              ? <div className="copied">Copied!</div>
+              : ''
+            }
+          </div>
         </div>
         <textarea
           className="hidden-copy-field"
@@ -142,7 +101,6 @@ const mapStateToProps = (state, ownProps) => {
   return {
     btcAddress: state.deposit.btcAddress,
     depositAddress: state.deposit.depositAddress,
-    btcConfirming: state.deposit.btcConfirming,
     lotInSatoshis: state.deposit.lotInSatoshis,
     signerFeeInSatoshis: state.deposit.signerFeeInSatoshis,
   }

--- a/src/components/deposit/Pay.js
+++ b/src/components/deposit/Pay.js
@@ -25,9 +25,11 @@ class PayComponent extends Component {
   }
 
   componentDidMount() {
-    const { autoSubmitDepositProof } = this.props
+    const { autoSubmitDepositProof, didSubmitDepositProof } = this.props
 
-    autoSubmitDepositProof()
+    if (!didSubmitDepositProof) {
+      autoSubmitDepositProof()
+    }
   }
 
   copyAddress = (evt) => {
@@ -103,6 +105,7 @@ const mapStateToProps = (state, ownProps) => {
     depositAddress: state.deposit.depositAddress,
     lotInSatoshis: state.deposit.lotInSatoshis,
     signerFeeInSatoshis: state.deposit.signerFeeInSatoshis,
+    didSubmitDepositProof: state.deposit.didSubmitDepositProof,
   }
 }
 

--- a/src/components/deposit/Prove.js
+++ b/src/components/deposit/Prove.js
@@ -25,7 +25,7 @@ class ProveComponent extends Component {
         </div>
         <div className="page-body">
           <div className="step">
-            Step 5/6
+            Step 4/5
           </div>
           <div className="title">
             {

--- a/src/components/deposit/Start.js
+++ b/src/components/deposit/Start.js
@@ -1,4 +1,4 @@
-import React, { Component, useEffect } from 'react'
+import React, { useEffect } from 'react'
 
 import history from '../../history'
 import { requestPermission } from '../../lib/notifications'

--- a/src/components/deposit/index.js
+++ b/src/components/deposit/index.js
@@ -5,6 +5,7 @@ import Congratulations from './Congratulations'
 import Start from './Start'
 import RequestDeposit from './RequestDeposit'
 import GetAddress from './GetAddress'
+import Confirming from './Confirming'
 
 export {
     Invoice,
@@ -13,5 +14,6 @@ export {
     Congratulations,
     Start,
     RequestDeposit,
-    GetAddress
+    GetAddress,
+    Confirming
 }

--- a/src/components/lib/ConnectWalletDialog.js
+++ b/src/components/lib/ConnectWalletDialog.js
@@ -1,5 +1,4 @@
-import React, { Component, useReducer, useState } from 'react'
-import Check from '../svgs/Check'
+import React, { useState } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import { InjectedConnector } from '@web3-react/injected-connector'
 
@@ -36,10 +35,6 @@ export const ConnectWalletDialog = ({ shown, onConnected }) => {
 
 	let [chosenWallet, setChosenWallet] = useState(null)
 	let [error, setError] = useState(null)
-	let state = {
-		chosenWallet,
-		error
-	}
 
 	async function chooseWallet(wallet) {
 		setChosenWallet(wallet)
@@ -64,7 +59,7 @@ export const ConnectWalletDialog = ({ shown, onConnected }) => {
 				{
 					WALLETS.map(({ name, icon, showName }) => {
 						return <li key={name} className='wallet-option' onClick={() => chooseWallet(name)}>
-							<img src={icon} />
+							<img src={icon} alt={`${name} icon`} />
 							{showName && name}
 						</li>
 					})

--- a/src/components/lib/Web3Status.js
+++ b/src/components/lib/Web3Status.js
@@ -1,10 +1,10 @@
-import React, { Component, useReducer, useState } from 'react'
+import React, { useState } from 'react'
 import Check from '../svgs/Check'
 import { useWeb3React } from '@web3-react/core'
 import { ConnectWalletDialog } from './ConnectWalletDialog'
 
 export const Web3Status = (props) => {
-	const { active, error } = useWeb3React()
+	const { active } = useWeb3React()
 
 	let [showConnectWallet, setShowConnectWallet] = useState(false)
 

--- a/src/components/redemption/Signing.js
+++ b/src/components/redemption/Signing.js
@@ -1,30 +1,49 @@
-import React, { Component } from 'react'
+import React, { useEffect } from 'react'
+import { bindActionCreators } from 'redux'
+import { connect } from 'react-redux'
 
 import StatusIndicator from '../svgs/StatusIndicator'
+import { resumeRedemption } from '../../actions'
 
-class Signing extends Component {
-  render() {
-    return (
-      <div className="confirming">
-        <div className="page-top">
-          <StatusIndicator pulse />
+const Signing = ({ resumeRedemption, redemptionInProgress }) => {
+  useEffect(() => {
+    if (!redemptionInProgress) {
+      resumeRedemption()
+    }
+  }, [resumeRedemption, redemptionInProgress])
+
+  return (
+    <div className="confirming">
+      <div className="page-top">
+        <StatusIndicator pulse />
+      </div>
+      <div className="page-body">
+        <div className="step">
+          Step 3/6
         </div>
-        <div className="page-body">
-          <div className="step">
-            Step 3/6
-          </div>
-          <div className="title">
-            Waiting on signing group
-          </div>
-          <hr />
-          <div className="description">
-            <p>We’re waiting for the deposit signing group to build and sign your Bitcoin transaction.</p>
-          </div>
+        <div className="title">
+          Waiting on signing group
+        </div>
+        <hr />
+        <div className="description">
+          <p>We’re waiting for the deposit signing group to build and sign your Bitcoin transaction.</p>
         </div>
       </div>
-    )
+    </div>
+  )
+}
+
+const mapStateToProps = (state) => {
+  return {
+    redemptionInProgress: !!state.redemption.redemption
   }
 }
 
-export default Signing
+const mapDispatchToProps = (dispatch) => {
+  return bindActionCreators({ resumeRedemption }, dispatch)
+}
 
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Signing)

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import routerMiddleware from './lib/router/middleware'
 import notificationMiddleware from './lib/notifications/middleware'
 import { Provider } from 'react-redux'
 import { Router, Route } from 'react-router-dom'
+import { composeWithDevTools } from 'redux-devtools-extension'
 
 // Styles
 import './css/app.scss'
@@ -52,7 +53,9 @@ const middleware = [
 
 const store = createStore(
   reducers,
-  applyMiddleware(...middleware),
+  composeWithDevTools(
+    applyMiddleware(...middleware)
+  ),
 )
 
 sagaMiddleware.run(sagas)

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,8 @@ import { createStore, applyMiddleware } from 'redux'
 import createSagaMiddleware from 'redux-saga'
 import routerMiddleware from './lib/router/middleware'
 import notificationMiddleware from './lib/notifications/middleware'
-import { Provider, useSelector } from 'react-redux'
-import { Router, Route, useParams } from 'react-router-dom'
+import { Provider } from 'react-redux'
+import { Router, Route } from 'react-router-dom'
 
 // Styles
 import './css/app.scss'
@@ -41,8 +41,6 @@ import Loadable, { RESTORER } from './wrappers/loadable'
 import sagas from './sagas'
 import reducers from './reducers'
 import history from './history'
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux'
 
 // Set up our store
 const sagaMiddleware = createSagaMiddleware()

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ import {
   Invoice,
   GetAddress,
   Pay,
+  Confirming as ConfirmingDeposit,
   Prove as ProveDeposit,
   Congratulations as CongratulationsDeposit
 } from './components/deposit'
@@ -76,7 +77,11 @@ function AppWrapper() {
                 <Pay />
               </Loadable>
             </Route>
-            <Route path="/deposit/:address/pay/confirming" render={(props) => <Loadable restorer={RESTORER.DEPOSIT}><Pay {...props} confirming={true} /></Loadable>} />
+            <Route path="/deposit/:address/pay/confirming">
+              <Loadable restorer={RESTORER.DEPOSIT}>
+                <ConfirmingDeposit />
+              </Loadable>
+            </Route>
             <Route path="/deposit/:address/prove">
               <Loadable restorer={RESTORER.DEPOSIT}>
                 <ProveDeposit />

--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,11 @@ function AppWrapper() {
             <Route path="/" exact component={Home} />
             <Route path="/deposit" exact component={StartDeposit} />
             <Route path="/deposit/new" component={Invoice} />
-            <Route path="/deposit/:address/get-address" component={GetAddress} />
+            <Route path="/deposit/:address/get-address">
+              <Loadable restorer={RESTORER.DEPOSIT}>
+                <GetAddress />
+              </Loadable>
+            </Route>
             <Route path="/deposit/:address/pay" exact>
               <Loadable restorer={RESTORER.DEPOSIT}>
                 <Pay />

--- a/src/lib/notifications/middleware.js
+++ b/src/lib/notifications/middleware.js
@@ -2,7 +2,7 @@ import { iconPath } from ".";
 import { NEW_NOTIFICATION } from './actions'
 
 export default store => next => action => {
-    if(action.type == NEW_NOTIFICATION) {
+    if(action.type === NEW_NOTIFICATION) {
         new Notification('tBTC', {
             body: action.payload.body,
             icon: iconPath

--- a/src/lib/router/middleware.js
+++ b/src/lib/router/middleware.js
@@ -2,7 +2,7 @@ import history from '../../history'
 import { HISTORY_PUSH } from './actions';
 
 export default store => next => action => {
-    if(action.type == HISTORY_PUSH) {
+    if(action.type === HISTORY_PUSH) {
         history.push(action.payload.path)
     }
 

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -47,9 +47,6 @@ const deposit = (state = initialState, action) => {
         ...state,
         depositAddress: action.payload.depositAddress,
         invoiceStatus: 2,
-        // Flagging as true so that /get-address route can render the GetAddress
-        // component as expected since we are using the LoadableWrapper
-        stateRestored: true
       }
     case DEPOSIT_RESOLVED:
       return {

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -45,7 +45,10 @@ const deposit = (state = initialState, action) => {
       return {
         ...state,
         depositAddress: action.payload.depositAddress,
-        invoiceStatus: 2
+        invoiceStatus: 2,
+        // Flagging as true so that /get-address can render the GetAddress
+        // component as expected since we are using the LoadableWrapper
+        stateRestored: true
       }
     case DEPOSIT_RESOLVED:
       return {

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -46,7 +46,7 @@ const deposit = (state = initialState, action) => {
         ...state,
         depositAddress: action.payload.depositAddress,
         invoiceStatus: 2,
-        // Flagging as true so that /get-address can render the GetAddress
+        // Flagging as true so that /get-address route can render the GetAddress
         // component as expected since we are using the LoadableWrapper
         stateRestored: true
       }

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -51,7 +51,7 @@ const deposit = (state = initialState, action) => {
       return {
         ...state,
         deposit: action.payload.deposit,
-        invoiceStatus: 2
+        invoiceStatus: 3
       }
     case DEPOSIT_BTC_ADDRESS:
       return {

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -11,11 +11,12 @@ import {
   DEPOSIT_RESOLVED,
   DEPOSIT_STATE_RESTORED,
 } from "../sagas/deposit"
-import { RESTORE_DEPOSIT_STATE } from "../actions"
+import { AUTO_SUBMIT_DEPOSIT_PROOF, RESTORE_DEPOSIT_STATE } from "../actions"
 
 const initialState = {
   btcAddress: null,
   depositAddress: null,
+  didSubmitDepositProof: false,
   btcDepositedTxID: null,
   tbtcMintedTxID: null,
   fundingOutputIndex: null,
@@ -66,6 +67,11 @@ const deposit = (state = initialState, action) => {
         ...state,
         lotInSatoshis: action.payload.lotInSatoshis,
         signerFeeInSatoshis: action.payload.signerFeeInSatoshis,
+      }
+    case AUTO_SUBMIT_DEPOSIT_PROOF:
+      return {
+        ...state,
+        didSubmitDepositProof: true,
       }
     case BTC_TX_MINED:
       return {

--- a/src/reducers/redemption.js
+++ b/src/reducers/redemption.js
@@ -7,7 +7,7 @@ import {
     REDEMPTION_PROVE_BTC_TX_BEGIN,
     REDEMPTION_PROVE_BTC_TX_SUCCESS,
     REDEMPTION_PROVE_BTC_TX_ERROR,
-    REDEMPTION_REQUESTED
+    REDEMPTION_REQUEST_SUCCESS
 } from '../sagas/redemption'
 
 import { RESTORE_REDEMPTION_STATE } from "../actions"
@@ -20,7 +20,8 @@ const initialState = {
     txHash: null,
     requiredConfirmations: 1,
     confirmations: null,
-    pollForConfirmationsError: null
+    pollForConfirmationsError: null,
+    redemption: null,
 }
 
 const redemption = (state = initialState, action) => {
@@ -67,7 +68,7 @@ const redemption = (state = initialState, action) => {
                 ...state,
                 pollForConfirmationsError: action.payload.pollForConfirmationsError
             }
-        case REDEMPTION_REQUESTED:
+        case REDEMPTION_REQUEST_SUCCESS:
             return {
                 ...state,
                 redemption: action.payload.redemption,

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -174,6 +174,10 @@ export function* requestADeposit() {
             depositAddress: deposit.address,
         }
     })
+
+    // goto
+    yield put(navigateTo('/deposit/' + deposit.address + '/get-address'))
+
     yield put({
         type: DEPOSIT_RESOLVED,
         payload: {

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -54,10 +54,8 @@ function* restoreState(nextStepMap, stateKey) {
 
         // Funding flow.
         case tbtc.Deposit.State.AWAITING_SIGNER_SETUP:
-            // We want to flag `stateRestored` as true in the deposit reducer
-            // to be able to restart the flow from page refresh
             yield put({
-                type: DEPOSIT_REQUEST_SUCCESS,
+                type: DEPOSIT_STATE_RESTORED,
                 payload: {
                     depositAddress,
                 }

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -70,6 +70,14 @@ function* restoreState(nextStepMap, stateKey) {
             // Explicitly fall through.
 
         case tbtc.Deposit.State.AWAITING_WITHDRAWAL_SIGNATURE:
+            yield put({
+                type: DEPOSIT_STATE_RESTORED,
+                payload: {
+                    depositAddress,
+                }
+            })
+            finalCalls = resumeRedemption
+
         case tbtc.Deposit.State.AWAITING_BTC_FUNDING_PROOF:
         case tbtc.Deposit.State.REDEEMED:
         case tbtc.Deposit.State.ACTIVE:

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -54,6 +54,15 @@ function* restoreState(nextStepMap, stateKey) {
 
         // Funding flow.
         case tbtc.Deposit.State.AWAITING_SIGNER_SETUP:
+            // We want to flag `stateRestored` as true in the deposit reducer
+            // to be able to restart the flow from page refresh
+            yield put({
+                type: DEPOSIT_REQUEST_SUCCESS,
+                payload: {
+                    depositAddress,
+                }
+            })
+
             yield put(navigateTo('/deposit/' + depositAddress + '/get-address'))
             break
 
@@ -184,6 +193,14 @@ export function* requestADeposit() {
              deposit,
         }
     })
+}
+
+export function* getBitcoinAddress() {
+    /** @type {TBTC} */
+    const tbtc = yield TBTCLoaded
+
+    /** @type Deposit */
+    const deposit = yield select(state => state.deposit.deposit)
 
     const btcAddress = yield deposit.bitcoinAddress
 

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -228,6 +228,9 @@ export function* autoSubmitDepositProof() {
         type: BTC_TX_CONFIRMED_WAIT
     })
 
+    // goto
+    yield put(navigateTo('/deposit/' + deposit.address + '/pay/confirming'))
+
     yield autoSubmission.fundingConfirmations
 
     // when it's finally sufficiently confirmed, dispatch the txid

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -54,7 +54,7 @@ function* restoreState(nextStepMap, stateKey) {
 
         // Funding flow.
         case tbtc.Deposit.State.AWAITING_SIGNER_SETUP:
-            yield put(navigateTo('/deposit/' + depositAddress + '/generate-address'))
+            yield put(navigateTo('/deposit/' + depositAddress + '/get-address'))
             break
 
         case tbtc.Deposit.State.AWAITING_WITHDRAWAL_PROOF:

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -52,18 +52,6 @@ function* restoreState(nextStepMap, stateKey) {
         case tbtc.Deposit.State.START:
             throw new Error("Unexpected state.")
 
-        // Funding flow.
-        case tbtc.Deposit.State.AWAITING_SIGNER_SETUP:
-            yield put({
-                type: DEPOSIT_STATE_RESTORED,
-                payload: {
-                    depositAddress,
-                }
-            })
-
-            yield put(navigateTo('/deposit/' + depositAddress + '/get-address'))
-            break
-
         case tbtc.Deposit.State.AWAITING_WITHDRAWAL_PROOF:
             finalCalls = resumeRedemption
             nextStep = "/redemption/prove"
@@ -77,6 +65,7 @@ function* restoreState(nextStepMap, stateKey) {
                 }
             })
             finalCalls = resumeRedemption
+            // Explicitly fall through.
 
         case tbtc.Deposit.State.AWAITING_BTC_FUNDING_PROOF:
         case tbtc.Deposit.State.REDEEMED:
@@ -88,7 +77,9 @@ function* restoreState(nextStepMap, stateKey) {
                     btcAddress,
                 }
             })
+            // Explicitly fall through.
 
+        case tbtc.Deposit.State.AWAITING_SIGNER_SETUP:
             const lotInSatoshis = yield call([deposit, deposit.getSatoshiLotSize])
             const signerFeeTbtc = yield call([deposit, deposit.getSignerFeeTBTC])
             const signerFeeInSatoshis = signerFeeTbtc.div(tbtc.satoshisPerTbtc)
@@ -146,6 +137,7 @@ export function* restoreDepositState() {
     const tbtc = yield TBTCLoaded
 
     const DEPOSIT_STEP_MAP = {};
+    DEPOSIT_STEP_MAP[tbtc.Deposit.State.AWAITING_SIGNER_SETUP] = '/get-address'
     DEPOSIT_STEP_MAP[tbtc.Deposit.State.AWAITING_BTC_FUNDING_PROOF] = "/pay"
     DEPOSIT_STEP_MAP[tbtc.Deposit.State.ACTIVE] = "/congratulations"
 

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -58,15 +58,6 @@ function* restoreState(nextStepMap, stateKey) {
             // Explicitly fall through.
 
         case tbtc.Deposit.State.AWAITING_WITHDRAWAL_SIGNATURE:
-            yield put({
-                type: DEPOSIT_STATE_RESTORED,
-                payload: {
-                    depositAddress,
-                }
-            })
-            finalCalls = resumeRedemption
-            // Explicitly fall through.
-
         case tbtc.Deposit.State.AWAITING_BTC_FUNDING_PROOF:
         case tbtc.Deposit.State.REDEEMED:
         case tbtc.Deposit.State.ACTIVE:

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -100,7 +100,7 @@ function* restoreState(nextStepMap, stateKey) {
             })
 
             const inVendingMachine = yield call([deposit, deposit.inVendingMachine])
-            if (depositState == tbtc.Deposit.State.ACTIVE && ! inVendingMachine) {
+            if (depositState === tbtc.Deposit.State.ACTIVE && ! inVendingMachine) {
                 yield call([deposit, deposit.mintTBTC])
             }
 

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -11,6 +11,7 @@ import {
 import {
     saveAddresses,
     requestRedemption,
+    resumeRedemption,
 } from './redemption'
 import {
     RESTORE_DEPOSIT_STATE,
@@ -20,6 +21,7 @@ import {
     AUTO_SUBMIT_DEPOSIT_PROOF,
     SAVE_ADDRESSES,
     REQUEST_REDEMPTION,
+    RESUME_REDEMPTION,
 } from '../actions'
 
 export default function* () {
@@ -30,4 +32,5 @@ export default function* () {
     yield takeLatest(AUTO_SUBMIT_DEPOSIT_PROOF, autoSubmitDepositProof)
     yield takeLatest(SAVE_ADDRESSES, saveAddresses)
     yield takeLatest(REQUEST_REDEMPTION, requestRedemption)
+    yield takeLatest(RESUME_REDEMPTION, resumeRedemption)
 }

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -4,6 +4,7 @@ import {
     restoreDepositState,
     restoreRedemptionState,
     requestADeposit,
+    getBitcoinAddress,
     autoSubmitDepositProof 
 } from './deposit'
 
@@ -15,6 +16,7 @@ import {
     RESTORE_DEPOSIT_STATE,
     RESTORE_REDEMPTION_STATE,
     REQUEST_A_DEPOSIT,
+    GET_BITCOIN_ADDRESS,
     AUTO_SUBMIT_DEPOSIT_PROOF,
     SAVE_ADDRESSES,
     REQUEST_REDEMPTION,
@@ -24,6 +26,7 @@ export default function* () {
     yield takeLatest(RESTORE_DEPOSIT_STATE, restoreDepositState)
     yield takeLatest(RESTORE_REDEMPTION_STATE, restoreRedemptionState)
     yield takeLatest(REQUEST_A_DEPOSIT, requestADeposit)
+    yield takeLatest(GET_BITCOIN_ADDRESS, getBitcoinAddress)
     yield takeLatest(AUTO_SUBMIT_DEPOSIT_PROOF, autoSubmitDepositProof)
     yield takeLatest(SAVE_ADDRESSES, saveAddresses)
     yield takeLatest(REQUEST_REDEMPTION, requestRedemption)

--- a/src/sagas/redemption.js
+++ b/src/sagas/redemption.js
@@ -98,7 +98,7 @@ function* runRedemption(redemption) {
         yield put({
             type: REDEMPTION_PROVE_BTC_TX_ERROR,
             payload: {
-                error,
+                error: error.message
             }
         })
     }

--- a/src/sagas/redemption.js
+++ b/src/sagas/redemption.js
@@ -13,7 +13,7 @@ export const UPDATE_TRANSACTION_AND_SIGNATURE = 'UPDATE_TRANSACTION_AND_SIGNATUR
 export const UPDATE_TX_HASH = 'UPDATE_TX_HASH'
 export const UPDATE_CONFIRMATIONS = 'UPDATE_CONFIRMATIONS'
 export const POLL_FOR_CONFIRMATIONS_ERROR = 'POLL_FOR_CONFIRMATIONS_ERROR'
-export const REDEMPTION_REQUESTED = 'REDEMPTION_REQUESTED'
+export const REDEMPTION_REQUEST_SUCCESS = 'REDEMPTION_REQUEST_SUCCESS'
 export const REDEMPTION_PROVE_BTC_TX_BEGIN = 'REDEMPTION_PROVE_BTC_TX_BEGIN'
 export const REDEMPTION_PROVE_BTC_TX_SUCCESS = 'REDEMPTION_PROVE_BTC_TX_SUCCESS'
 export const REDEMPTION_PROVE_BTC_TX_ERROR = 'REDEMPTION_PROVE_BTC_TX_ERROR'
@@ -47,6 +47,13 @@ export function* requestRedemption() {
 
     /** @type {Redemption} */
     const redemption = yield call([deposit, deposit.requestRedemption], btcAddress)
+    yield put({
+        type: REDEMPTION_REQUEST_SUCCESS,
+        payload: {
+            redemption
+        }
+    })
+
     yield* runRedemption(redemption)
 }
 
@@ -61,7 +68,7 @@ export function* resumeRedemption() {
     const redemption = yield call([deposit, deposit.getCurrentRedemption])
 
     yield put({
-        type: REDEMPTION_REQUESTED,
+        type: REDEMPTION_REQUEST_SUCCESS,
         payload: {
             redemption
         }

--- a/src/wrappers/loadable.js
+++ b/src/wrappers/loadable.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { Router, Route, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { bindActionCreators } from 'redux'
 import { connect, useSelector } from 'react-redux'
 import { restoreDepositState, restoreRedemptionState } from '../actions';
@@ -10,7 +10,7 @@ export const RESTORER = {
   REDEMPTION: 'redemption'
 }
 
-function LoadableBase({ children, account, restoreDepositState, restoreRedemptionState, restorer }) {
+function LoadableBase({ children, restoreDepositState, restoreRedemptionState, restorer }) {
     // Wait for web3 connected
     const { active: web3Active } = useWeb3React()
     const { address } = useParams()
@@ -18,12 +18,12 @@ function LoadableBase({ children, account, restoreDepositState, restoreRedemptio
     
     useEffect(() => {
         if(web3Active && address && ! depositStateRestored) {
-            if (restorer == RESTORER.DEPOSIT) {
+            if (restorer === RESTORER.DEPOSIT) {
                 restoreDepositState(address)
-            } else if (restorer == RESTORER.REDEMPTION) {
+            } else if (restorer === RESTORER.REDEMPTION) {
                 restoreRedemptionState(address)
             } else {
-                throw "Unknown restorer."
+                throw new Error("Unknown restorer.")
             }
         }
     }, [web3Active, address, depositStateRestored, restorer, restoreDepositState, restoreRedemptionState])

--- a/src/wrappers/web3.js
+++ b/src/wrappers/web3.js
@@ -1,4 +1,4 @@
-import React, { Component, useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import Web3 from 'web3'
 import TBTC from '@keep-network/tbtc.js'
 import { Web3ReactProvider, useWeb3React } from '@web3-react/core'
@@ -64,13 +64,13 @@ function instantiateWeb3(provider, connector) {
 }
 
 const Web3ReactManager = ({ children }) => {
-    const { activate, active, library, connector } = useWeb3React()
+    const { active, library, connector } = useWeb3React()
 
     useEffect(() => {
         if(active) {
             initializeContracts(library, connector)
         }
-    }, [active])
+    }, [active, connector, library])
 
     // Watch for changes:
     // provider = this.state.web3.eth.currentProvider


### PR DESCRIPTION
Fills in missing urls in both the deposit and redemption flows. These urls already existed but were not in use. Addresses the first part of #218.

In the deposit flow, this enables:
- `/deposit/<deposit-address>/get-address`
- `/deposit/<deposit-address>/pay/confirming`

The `GetAddress` component is now wrapped in a `<Loadable/>` component wrapper and calls a new action `getBitcoinAddress` (split out from the `requestDeposit` saga)  to allow the /get-address route restart the deposit flow in case the user refreshes the page.

This also splits out a new `Confirming` component out of the `Pay` component for the deposit flow to match the url and make it a little easier to read (the original `Pay` component had a lot of conditional logic for rendering).

In the redemption flow:
- Refreshing `/deposit/<deposit-address/redemption/signing` now allows the user to resume the in-flight redemption
- `/deposit/<deposit-address/redemption/prove` is now integrated into the flow ("Step 5/6", previously missing). This update relies on a change to tbtc.js: https://github.com/keep-network/tbtc.js/pull/47. 

Lastly, this also PR fixes a bit of linting and adds redux devtools for easier debugging. There is a new .git-blame-ignore-revs file to help out with history.