### PR TITLE
Catch and display errors to enable easier restarts

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -34,18 +34,11 @@ export function restoreRedemptionState(depositAddress) {
 
 // Deposit
 export const REQUEST_A_DEPOSIT = 'REQUEST_A_DEPOSIT'
-export const GET_BITCOIN_ADDRESS = 'GET_BITCOIN_ADDRESS'
 export const AUTO_SUBMIT_DEPOSIT_PROOF = 'AUTO_SUBMIT_DEPOSIT_PROOF'
 
 export function requestADeposit() {
     return {
         type: REQUEST_A_DEPOSIT,
-    }
-}
-
-export function getBitcoinAddress() {
-    return {
-        type: GET_BITCOIN_ADDRESS,
     }
 }
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -34,17 +34,10 @@ export function restoreRedemptionState(depositAddress) {
 
 // Deposit
 export const REQUEST_A_DEPOSIT = 'REQUEST_A_DEPOSIT'
-export const AUTO_SUBMIT_DEPOSIT_PROOF = 'AUTO_SUBMIT_DEPOSIT_PROOF'
 
 export function requestADeposit() {
     return {
         type: REQUEST_A_DEPOSIT,
-    }
-}
-
-export function autoSubmitDepositProof() {
-    return {
-        type: AUTO_SUBMIT_DEPOSIT_PROOF,
     }
 }
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -44,7 +44,6 @@ export function requestADeposit() {
 // Redemption
 export const SAVE_ADDRESSES = 'SAVE_ADDRESSES'
 export const REQUEST_REDEMPTION = 'REQUEST_REDEMPTION'
-export const RESUME_REDEMPTION = 'RESUME_REDEMPTION'
 
 export function saveAddresses({ btcAddress, depositAddress }) {
     return {
@@ -59,12 +58,6 @@ export function saveAddresses({ btcAddress, depositAddress }) {
 export function requestRedemption() {
     return {
         type: REQUEST_REDEMPTION,
-    }
-}
-
-export function resumeRedemption() {
-    return {
-        type: RESUME_REDEMPTION
     }
 }
 

--- a/src/components/deposit/Confirming.js
+++ b/src/components/deposit/Confirming.js
@@ -8,7 +8,7 @@ import { BitcoinHelpers } from '@keep-network/tbtc.js'
 import BigNumber from "bignumber.js"
 BigNumber.set({ DECIMAL_PLACES: 8 })
 
-const Confirming = ({ signerFeeInSatoshis }) => {
+const Confirming = ({ signerFeeInSatoshis, error }) => {
   const signerFee = (new BigNumber(signerFeeInSatoshis.toString()))
     .div(BitcoinHelpers.satoshisPerBtc.toString()).toString()
 
@@ -22,7 +22,7 @@ const Confirming = ({ signerFeeInSatoshis }) => {
           Step 3/5
         </div>
         <div className="title">
-          Confirming...
+          { error ? 'Error confirming transaction' : 'Confirming...' }
         </div>
         <hr />
         <div className="description">
@@ -36,6 +36,9 @@ const Confirming = ({ signerFeeInSatoshis }) => {
             {signerFee} BTC*
           </div>
         </div>
+        <div className="error">
+          { error }
+        </div>
       </div>
     </div>
   )
@@ -44,6 +47,7 @@ const Confirming = ({ signerFeeInSatoshis }) => {
 const mapStateToProps = (state) => {
   return {
     signerFeeInSatoshis: state.deposit.signerFeeInSatoshis,
+    error: state.deposit.btcConfirmingError,
   }
 }
 

--- a/src/components/deposit/Confirming.js
+++ b/src/components/deposit/Confirming.js
@@ -1,8 +1,6 @@
-import React, { useEffect } from 'react'
-import { bindActionCreators } from 'redux'
+import React from 'react'
 import { connect } from 'react-redux'
 
-import { autoSubmitDepositProof } from '../../actions'
 import StatusIndicator from '../svgs/StatusIndicator'
 
 import { BitcoinHelpers } from '@keep-network/tbtc.js'
@@ -10,17 +8,7 @@ import { BitcoinHelpers } from '@keep-network/tbtc.js'
 import BigNumber from "bignumber.js"
 BigNumber.set({ DECIMAL_PLACES: 8 })
 
-const Confirming = ({
-  autoSubmitDepositProof,
-  didSubmitDepositProof,
-  signerFeeInSatoshis
-}) => {
-  useEffect(() => {
-    if (!didSubmitDepositProof) {
-      autoSubmitDepositProof()
-    }
-  }, [autoSubmitDepositProof, didSubmitDepositProof])
-
+const Confirming = ({ signerFeeInSatoshis }) => {
   const signerFee = (new BigNumber(signerFeeInSatoshis.toString()))
     .div(BitcoinHelpers.satoshisPerBtc.toString()).toString()
 
@@ -53,23 +41,13 @@ const Confirming = ({
   )
 }
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   return {
     signerFeeInSatoshis: state.deposit.signerFeeInSatoshis,
-    didSubmitDepositProof: state.deposit.didSubmitDepositProof,
   }
-}
-
-const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators(
-  {
-    autoSubmitDepositProof
-  },
-  dispatch
-  )
 }
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  null
 )(Confirming)

--- a/src/components/deposit/GetAddress.js
+++ b/src/components/deposit/GetAddress.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux'
 import StatusIndicator from '../svgs/StatusIndicator'
 import { getBitcoinAddress } from '../../actions'
 
-const GetAddress = ({ status, getBitcoinAddress }) => {
+const GetAddress = ({ status, getBitcoinAddress, btcAddressError }) => {
   useEffect(() => {
     getBitcoinAddress()
   }, [getBitcoinAddress])
@@ -33,6 +33,9 @@ const GetAddress = ({ status, getBitcoinAddress }) => {
         <div className="description">
           {statusText}
         </div>
+        <div className="error">
+          { btcAddressError }
+        </div>
       </div>
     </div >
   )
@@ -40,7 +43,8 @@ const GetAddress = ({ status, getBitcoinAddress }) => {
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    status: state.deposit.invoiceStatus
+    status: state.deposit.invoiceStatus,
+    btcAddressError: state.deposit.btcAddressError,
   }
 }
 

--- a/src/components/deposit/GetAddress.js
+++ b/src/components/deposit/GetAddress.js
@@ -1,15 +1,9 @@
 import React, { useState, useEffect } from 'react'
-import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 
 import StatusIndicator from '../svgs/StatusIndicator'
-import { getBitcoinAddress } from '../../actions'
 
-const GetAddress = ({ status, getBitcoinAddress, btcAddressError }) => {
-  useEffect(() => {
-    getBitcoinAddress()
-  }, [getBitcoinAddress])
-
+const GetAddress = ({ status, btcAddressError }) => {
   const [statusText, setStatusText] = useState('Generating BTC address...')
   useEffect(() => {
     if (status === 3) {
@@ -48,16 +42,7 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators(
-  {
-    getBitcoinAddress
-  },
-  dispatch
-  )
-}
-
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  null,
 )(GetAddress)

--- a/src/components/deposit/Invoice.js
+++ b/src/components/deposit/Invoice.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux'
 import { requestADeposit } from '../../actions'
 import StatusIndicator from '../svgs/StatusIndicator'
 
-const Invoice = ({ requestADeposit }) => {
+const Invoice = ({ requestADeposit, error }) => {
   useEffect(() => {
     requestADeposit()
   }, [requestADeposit])
@@ -20,16 +20,23 @@ const Invoice = ({ requestADeposit }) => {
           Step 2/5
         </div>
         <div className="title">
-          Initiating deposit
+          { error ? 'Error initiating deposit' : 'Initiating deposit' }
         </div>
         <hr />
         <div className="description">
           Initiating...
         </div>
+        <div className="error">
+          { error }
+        </div>
       </div>
     </div >
   )
 }
+
+const mapStateToProps = (state) => ({
+  error: state.deposit.requestDepositError,
+})
 
 const mapDispatchToProps = (dispatch) => {
   return bindActionCreators(
@@ -41,6 +48,6 @@ const mapDispatchToProps = (dispatch) => {
 }
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps
 )(Invoice)

--- a/src/components/deposit/Pay.js
+++ b/src/components/deposit/Pay.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react'
-import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 
-import { autoSubmitDepositProof } from '../../actions'
 import QRCode from 'qrcode.react'
 import { useParams } from "react-router-dom"
 
@@ -21,14 +19,6 @@ class PayComponent extends Component {
     copied: false,
     deposit: {
       depositAddress: this.props.address
-    }
-  }
-
-  componentDidMount() {
-    const { autoSubmitDepositProof, didSubmitDepositProof } = this.props
-
-    if (!didSubmitDepositProof) {
-      autoSubmitDepositProof()
     }
   }
 
@@ -99,26 +89,16 @@ class PayComponent extends Component {
 }
 
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   return {
     btcAddress: state.deposit.btcAddress,
     depositAddress: state.deposit.depositAddress,
     lotInSatoshis: state.deposit.lotInSatoshis,
     signerFeeInSatoshis: state.deposit.signerFeeInSatoshis,
-    didSubmitDepositProof: state.deposit.didSubmitDepositProof,
   }
-}
-
-const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators(
-    {
-      autoSubmitDepositProof
-    },
-    dispatch
-  )
 }
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  null
 )(Pay)

--- a/src/components/deposit/Pay.js
+++ b/src/components/deposit/Pay.js
@@ -30,7 +30,7 @@ class PayComponent extends Component {
   }
 
   render() {
-    const { btcAddress, lotInSatoshis, signerFeeInSatoshis } = this.props
+    const { btcAddress, lotInSatoshis, signerFeeInSatoshis, error } = this.props
     const lotInBtc = (new BigNumber(lotInSatoshis.toString())).div(BitcoinHelpers.satoshisPerBtc.toString())
     const signerFeeInBtc = (new BigNumber(signerFeeInSatoshis.toString())).div(BitcoinHelpers.satoshisPerBtc.toString())
 
@@ -78,6 +78,9 @@ class PayComponent extends Component {
               : ''
             }
           </div>
+          <div className="error">
+            { error }
+          </div>
         </div>
         <textarea
           className="hidden-copy-field"
@@ -95,6 +98,7 @@ const mapStateToProps = (state) => {
     depositAddress: state.deposit.depositAddress,
     lotInSatoshis: state.deposit.lotInSatoshis,
     signerFeeInSatoshis: state.deposit.signerFeeInSatoshis,
+    error: state.deposit.btcTxError,
   }
 }
 

--- a/src/components/redemption/Confirming.js
+++ b/src/components/redemption/Confirming.js
@@ -15,9 +15,7 @@ class Confirming extends Component {
 
   render() {
     const {
-      confirmations,
-      requiredConfirmations,
-      pollForConfirmationsError,
+      error,
       txHash
     } = this.props
 
@@ -31,19 +29,11 @@ class Confirming extends Component {
             Step 4/6
           </div>
           <div className="title">
-            {
-              confirmations
-              ? `${confirmations}/${requiredConfirmations} blocks confirmed...`
-              : 'Broadcasting Transaction'
-            }
+            { error ? 'Error confirming transaction' : 'Confirming...' }
           </div>
           <hr />
           <div className="description">
-            {
-              confirmations
-              ? <p>We're waiting to confirm your transaction.</p>
-              : <p>Broadcasting your transaction...</p>
-            }
+            <p>We're waiting to confirm your transaction.</p>
             {
               txHash
               ? <button
@@ -55,9 +45,9 @@ class Confirming extends Component {
               : ''
             }
             {
-              pollForConfirmationsError
+              error
               ? <div className="error">
-                  { pollForConfirmationsError }
+                  { error }
                 </div>
               : ''
             }
@@ -68,12 +58,10 @@ class Confirming extends Component {
   }
 }
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   return {
     txHash: state.redemption.txHash,
-    confirmations: state.redemption.confirmations,
-    requiredConfirmations: state.redemption.requiredConfirmations,
-    pollForConfirmationsError: state.redemption.pollForConfirmationsError
+    error: state.redemption.pollForConfirmationsError,
   }
 }
 

--- a/src/components/redemption/Confirming.js
+++ b/src/components/redemption/Confirming.js
@@ -5,10 +5,10 @@ import StatusIndicator from '../svgs/StatusIndicator'
 
 class Confirming extends Component {
   handleClickButton = () => {
-    const { txHash } = this.props
+    const { txHash, btcNetwork } = this.props
 
     window.open(
-      `https://blockstream.info/tx/${txHash}`,
+      `https://blockstream.info/${btcNetwork === 'testnet' ? 'testnet/' : ''}tx/${txHash}`,
       '_blank'
     );
   }
@@ -62,6 +62,7 @@ const mapStateToProps = (state) => {
   return {
     txHash: state.redemption.txHash,
     error: state.redemption.pollForConfirmationsError,
+    btcNetwork: state.redemption.btcNetwork,
   }
 }
 

--- a/src/components/redemption/Redeeming.js
+++ b/src/components/redemption/Redeeming.js
@@ -11,7 +11,7 @@ function Redeeming(props) {
   return <RedeemingComponent {...props} address={props.address || params.address} />
 }
 
-const RedeemingComponent = ({ requestRedemption, requestRedemptionError }) => {
+const RedeemingComponent = ({ requestRedemption, error }) => {
   useEffect(() => {
     requestRedemption()
   }, [requestRedemption])
@@ -26,14 +26,14 @@ const RedeemingComponent = ({ requestRedemption, requestRedemptionError }) => {
           Step 2/6
         </div>
         <div className="title">
-          Redeeming...
+          { error ? 'Error redeeming bond' : 'Redeeming...'}
         </div>
         <hr />
         <div className="description">
           <p>We’re waiting for you to confirm invoice details in your Wallet.</p>
         </div>
         <div className="error">
-          { requestRedemptionError }
+          { error }
         </div>
       </div>
     </div>
@@ -41,7 +41,7 @@ const RedeemingComponent = ({ requestRedemption, requestRedemptionError }) => {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-  requestRedemptionError: state.redemption.requestRedemptionError,
+  error: state.redemption.requestRedemptionError,
 })
 
 const mapDispatchToProps = (dispatch) => {

--- a/src/components/redemption/Redeeming.js
+++ b/src/components/redemption/Redeeming.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { useEffect } from 'react'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import { useParams } from 'react-router-dom'
@@ -11,35 +11,38 @@ function Redeeming(props) {
   return <RedeemingComponent {...props} address={props.address || params.address} />
 }
 
-class RedeemingComponent extends Component {
-  componentDidMount() {
-    const { requestRedemption } = this.props
-
+const RedeemingComponent = ({ requestRedemption, requestRedemptionError }) => {
+  useEffect(() => {
     requestRedemption()
-  }
+  }, [requestRedemption])
 
-  render() {
-    return (
-      <div className="confirming">
-        <div className="page-top">
-          <StatusIndicator pulse />
+  return (
+    <div className="confirming">
+      <div className="page-top">
+        <StatusIndicator pulse />
+      </div>
+      <div className="page-body">
+        <div className="step">
+          Step 2/6
         </div>
-        <div className="page-body">
-          <div className="step">
-            Step 2/6
-          </div>
-          <div className="title">
-            Redeeming...
-          </div>
-          <hr />
-          <div className="description">
-            <p>We’re waiting for you to confirm invoice details in your Wallet.</p>
-          </div>
+        <div className="title">
+          Redeeming...
+        </div>
+        <hr />
+        <div className="description">
+          <p>We’re waiting for you to confirm invoice details in your Wallet.</p>
+        </div>
+        <div className="error">
+          { requestRedemptionError }
         </div>
       </div>
-    )
-  }
+    </div>
+  )
 }
+
+const mapStateToProps = (state, ownProps) => ({
+  requestRedemptionError: state.redemption.requestRedemptionError,
+})
 
 const mapDispatchToProps = (dispatch) => {
   return bindActionCreators(
@@ -51,7 +54,7 @@ const mapDispatchToProps = (dispatch) => {
 }
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps
 )(Redeeming)
 

--- a/src/components/redemption/Signing.js
+++ b/src/components/redemption/Signing.js
@@ -1,8 +1,9 @@
 import React from 'react'
+import { connect } from 'react-redux'
 
 import StatusIndicator from '../svgs/StatusIndicator'
 
-const Signing = () => {
+const Signing = ({ error }) => {
   return (
     <div className="confirming">
       <div className="page-top">
@@ -13,15 +14,24 @@ const Signing = () => {
           Step 3/6
         </div>
         <div className="title">
-          Waiting on signing group
+          { error ? 'Error signing your transaction' : 'Waiting on signing group' }
         </div>
         <hr />
         <div className="description">
           <p>We’re waiting for the deposit signing group to build and sign your Bitcoin transaction.</p>
+        </div>
+        <div className="error">
+          { error }
         </div>
       </div>
     </div>
   )
 }
 
-export default Signing
+const mapStateToProps = (state) => ({
+  error: state.redemption.signTxError,
+})
+
+export default connect(
+  mapStateToProps,
+)(Signing)

--- a/src/components/redemption/Signing.js
+++ b/src/components/redemption/Signing.js
@@ -1,17 +1,8 @@
-import React, { useEffect } from 'react'
-import { bindActionCreators } from 'redux'
-import { connect } from 'react-redux'
+import React from 'react'
 
 import StatusIndicator from '../svgs/StatusIndicator'
-import { resumeRedemption } from '../../actions'
 
-const Signing = ({ resumeRedemption, redemptionInProgress }) => {
-  useEffect(() => {
-    if (!redemptionInProgress) {
-      resumeRedemption()
-    }
-  }, [resumeRedemption, redemptionInProgress])
-
+const Signing = () => {
   return (
     <div className="confirming">
       <div className="page-top">
@@ -33,17 +24,4 @@ const Signing = ({ resumeRedemption, redemptionInProgress }) => {
   )
 }
 
-const mapStateToProps = (state) => {
-  return {
-    redemptionInProgress: !!state.redemption.redemption
-  }
-}
-
-const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators({ resumeRedemption }, dispatch)
-}
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Signing)
+export default Signing

--- a/src/css/structure.scss
+++ b/src/css/structure.scss
@@ -50,7 +50,8 @@
             flex: 1 1;
             font-size: .7em;
             color: $alert;
-            margin-top: 25px;
+            margin: 25px 0;
+            word-break: break-word;
         }
     }
 }

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -1,5 +1,6 @@
 import {
   DEPOSIT_REQUEST_SUCCESS,
+  DEPOSIT_REQUEST_ERROR,
   DEPOSIT_BTC_ADDRESS,
   DEPOSIT_BTC_ADDRESS_ERROR,
   DEPOSIT_BTC_AMOUNTS,
@@ -52,6 +53,11 @@ const deposit = (state = initialState, action) => {
         depositAddress: action.payload.depositAddress,
         invoiceStatus: 2,
         isStateReady: true
+      }
+    case DEPOSIT_REQUEST_ERROR:
+      return {
+        ...state,
+        requestDepositError: action.payload.error,
       }
     case DEPOSIT_RESOLVED:
       return {

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -23,7 +23,7 @@ const initialState = {
   fundingOutputIndex: null,
   btcConfirming: false,
   invoiceStatus: 0,
-  stateRestored: false,
+  isStateReady: false,
 }
 
 const deposit = (state = initialState, action) => {
@@ -36,7 +36,7 @@ const deposit = (state = initialState, action) => {
     case DEPOSIT_STATE_RESTORED:
       return {
         ...state,
-        stateRestored: true,
+        isStateReady: true,
       }
     case DEPOSIT_REQUEST_BEGIN:
       return {
@@ -48,9 +48,7 @@ const deposit = (state = initialState, action) => {
         ...state,
         depositAddress: action.payload.depositAddress,
         invoiceStatus: 2,
-        // Flagging as true so that /get-address route can render the GetAddress
-        // component as expected since we are using the LoadableWrapper
-        stateRestored: true
+        isStateReady: true
       }
     case DEPOSIT_RESOLVED:
       return {

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -1,8 +1,9 @@
 import {
   DEPOSIT_REQUEST_SUCCESS,
   DEPOSIT_BTC_ADDRESS,
-  DEPOSIT_BTC_ADDRESS_FAILED,
+  DEPOSIT_BTC_ADDRESS_ERROR,
   DEPOSIT_BTC_AMOUNTS,
+  DEPOSIT_BTC_AMOUNTS_ERROR,
   BTC_TX_MINED,
   BTC_TX_CONFIRMED_WAIT,
   DEPOSIT_AUTO_SUBMIT_PROOF,
@@ -64,7 +65,8 @@ const deposit = (state = initialState, action) => {
         btcAddress: action.payload.btcAddress,
         btcAddressError: undefined
       }
-    case DEPOSIT_BTC_ADDRESS_FAILED:
+    case DEPOSIT_BTC_ADDRESS_ERROR:
+    case DEPOSIT_BTC_AMOUNTS_ERROR:
       return {
         ...state,
         btcAddressError: action.payload.error,

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -5,7 +5,8 @@ import {
   DEPOSIT_BTC_ADDRESS_ERROR,
   DEPOSIT_BTC_AMOUNTS,
   DEPOSIT_BTC_AMOUNTS_ERROR,
-  BTC_TX_MINED,
+  BTC_TX_SEEN,
+  BTC_TX_ERROR,
   BTC_TX_CONFIRMED_WAIT,
   BTC_TX_CONFIRMED,
   BTC_TX_CONFIRMING_ERROR,
@@ -91,11 +92,16 @@ const deposit = (state = initialState, action) => {
         ...state,
         didSubmitDepositProof: true,
       }
-    case BTC_TX_MINED:
+    case BTC_TX_SEEN:
       return {
         ...state,
         btcDepositedTxID: action.payload.btcDepositedTxID,
         fundingOutputIndex: action.payload.fundingOutputIndex
+      }
+    case BTC_TX_ERROR:
+      return {
+        ...state,
+        btcTxError: action.payload.error,
       }
     case BTC_TX_CONFIRMED_WAIT:
       return {

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -5,6 +5,7 @@ import {
   DEPOSIT_BTC_AMOUNTS,
   BTC_TX_MINED,
   BTC_TX_CONFIRMED_WAIT,
+  DEPOSIT_AUTO_SUBMIT_PROOF,
   DEPOSIT_PROVE_BTC_TX_BEGIN,
   DEPOSIT_PROVE_BTC_TX_SUCCESS,
   DEPOSIT_PROVE_BTC_TX_ERROR,
@@ -12,7 +13,7 @@ import {
   DEPOSIT_RESOLVED,
   DEPOSIT_STATE_RESTORED,
 } from "../sagas/deposit"
-import { AUTO_SUBMIT_DEPOSIT_PROOF, RESTORE_DEPOSIT_STATE } from "../actions"
+import { RESTORE_DEPOSIT_STATE } from "../actions"
 
 const initialState = {
   btcAddress: null,
@@ -73,7 +74,7 @@ const deposit = (state = initialState, action) => {
         lotInSatoshis: action.payload.lotInSatoshis,
         signerFeeInSatoshis: action.payload.signerFeeInSatoshis,
       }
-    case AUTO_SUBMIT_DEPOSIT_PROOF:
+    case DEPOSIT_AUTO_SUBMIT_PROOF:
       return {
         ...state,
         didSubmitDepositProof: true,

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -1,6 +1,7 @@
 import {
   DEPOSIT_REQUEST_SUCCESS,
   DEPOSIT_BTC_ADDRESS,
+  DEPOSIT_BTC_ADDRESS_FAILED,
   DEPOSIT_BTC_AMOUNTS,
   BTC_TX_MINED,
   BTC_TX_CONFIRMED_WAIT,
@@ -57,7 +58,13 @@ const deposit = (state = initialState, action) => {
     case DEPOSIT_BTC_ADDRESS:
       return {
         ...state,
-        btcAddress: action.payload.btcAddress
+        btcAddress: action.payload.btcAddress,
+        btcAddressError: undefined
+      }
+    case DEPOSIT_BTC_ADDRESS_FAILED:
+      return {
+        ...state,
+        btcAddressError: action.payload.error,
       }
     case DEPOSIT_BTC_AMOUNTS:
       return {

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -9,6 +9,7 @@ import {
   DEPOSIT_PROVE_BTC_TX_BEGIN,
   DEPOSIT_PROVE_BTC_TX_SUCCESS,
   DEPOSIT_PROVE_BTC_TX_ERROR,
+  DEPOSIT_MINT_TBTC_ERROR,
   DEPOSIT_REQUEST_BEGIN,
   DEPOSIT_RESOLVED,
   DEPOSIT_STATE_RESTORED,
@@ -104,6 +105,7 @@ const deposit = (state = initialState, action) => {
         proveDepositError: undefined
       }
     case DEPOSIT_PROVE_BTC_TX_ERROR:
+    case DEPOSIT_MINT_TBTC_ERROR:
       return {
         ...state,
         provingDeposit: false,

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -48,6 +48,9 @@ const deposit = (state = initialState, action) => {
         ...state,
         depositAddress: action.payload.depositAddress,
         invoiceStatus: 2,
+        // Flagging as true so that /get-address route can render the GetAddress
+        // component as expected since we are using the LoadableWrapper
+        stateRestored: true
       }
     case DEPOSIT_RESOLVED:
       return {

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -7,6 +7,8 @@ import {
   DEPOSIT_BTC_AMOUNTS_ERROR,
   BTC_TX_MINED,
   BTC_TX_CONFIRMED_WAIT,
+  BTC_TX_CONFIRMED,
+  BTC_TX_CONFIRMING_ERROR,
   DEPOSIT_AUTO_SUBMIT_PROOF,
   DEPOSIT_PROVE_BTC_TX_BEGIN,
   DEPOSIT_PROVE_BTC_TX_SUCCESS,
@@ -26,6 +28,7 @@ const initialState = {
   tbtcMintedTxID: null,
   fundingOutputIndex: null,
   btcConfirming: false,
+  btcConfirmingTxID: null,
   invoiceStatus: 0,
   isStateReady: false,
 }
@@ -98,6 +101,16 @@ const deposit = (state = initialState, action) => {
       return {
         ...state,
         btcConfirming: true
+      }
+    case BTC_TX_CONFIRMED:
+      return {
+        ...state,
+        btcConfirmingTxID: action.payload.btcConfirmingTxID,
+      }
+    case BTC_TX_CONFIRMING_ERROR:
+      return {
+        ...state,
+        btcConfirmingError: action.payload.error,
       }
     case DEPOSIT_PROVE_BTC_TX_BEGIN:
       return {

--- a/src/reducers/redemption.js
+++ b/src/reducers/redemption.js
@@ -1,8 +1,6 @@
 import {
     UPDATE_ADDRESSES,
-    UPDATE_TRANSACTION_AND_SIGNATURE,
     UPDATE_TX_HASH,
-    UPDATE_CONFIRMATIONS,
     SIGN_TX_ERROR,
     POLL_FOR_CONFIRMATIONS_ERROR,
     REDEMPTION_PROVE_BTC_TX_BEGIN,
@@ -50,12 +48,6 @@ const redemption = (state = initialState, action) => {
                 btcAddress: action.payload.btcAddress,
                 depositAddress: action.payload.depositAddress
             }
-        case UPDATE_TRANSACTION_AND_SIGNATURE:
-            return {
-                ...state,
-                unsignedTransaction: action.payload.unsignedTransaction,
-                signature: action.payload.signature
-            }
         case SIGN_TX_ERROR:
             return {
                 ...state,
@@ -65,11 +57,6 @@ const redemption = (state = initialState, action) => {
             return {
                 ...state,
                 txHash: action.payload.txHash
-            }
-        case UPDATE_CONFIRMATIONS:
-            return {
-                ...state,
-                confirmations: action.payload.confirmations
             }
         case POLL_FOR_CONFIRMATIONS_ERROR:
             return {

--- a/src/reducers/redemption.js
+++ b/src/reducers/redemption.js
@@ -41,6 +41,7 @@ const redemption = (state = initialState, action) => {
             return {
                 ...state,
                 deposit: action.payload.deposit,
+                btcNetwork: action.payload.btcNetwork,
             }
         case UPDATE_ADDRESSES:
             return {

--- a/src/reducers/redemption.js
+++ b/src/reducers/redemption.js
@@ -7,7 +7,8 @@ import {
     REDEMPTION_PROVE_BTC_TX_BEGIN,
     REDEMPTION_PROVE_BTC_TX_SUCCESS,
     REDEMPTION_PROVE_BTC_TX_ERROR,
-    REDEMPTION_REQUEST_SUCCESS
+    REDEMPTION_REQUESTED,
+    REDEMPTION_REQUEST_FAILED,
 } from '../sagas/redemption'
 
 import { RESTORE_REDEMPTION_STATE } from "../actions"
@@ -68,10 +69,15 @@ const redemption = (state = initialState, action) => {
                 ...state,
                 pollForConfirmationsError: action.payload.pollForConfirmationsError
             }
-        case REDEMPTION_REQUEST_SUCCESS:
+        case REDEMPTION_REQUESTED:
             return {
                 ...state,
                 redemption: action.payload.redemption,
+            }
+        case REDEMPTION_REQUEST_FAILED:
+            return {
+                ...state,
+                requestRedemptionError: action.payload.error,
             }
         case REDEMPTION_PROVE_BTC_TX_BEGIN:
             return {

--- a/src/reducers/redemption.js
+++ b/src/reducers/redemption.js
@@ -23,6 +23,7 @@ const initialState = {
     confirmations: null,
     pollForConfirmationsError: null,
     redemption: null,
+    isStateReady: false,
 }
 
 const redemption = (state = initialState, action) => {
@@ -35,7 +36,7 @@ const redemption = (state = initialState, action) => {
         case DEPOSIT_STATE_RESTORED:
             return {
                 ...state,
-                stateRestored: true,
+                isStateReady: true,
             }
         case DEPOSIT_RESOLVED:
             return {

--- a/src/reducers/redemption.js
+++ b/src/reducers/redemption.js
@@ -8,7 +8,7 @@ import {
     REDEMPTION_PROVE_BTC_TX_SUCCESS,
     REDEMPTION_PROVE_BTC_TX_ERROR,
     REDEMPTION_REQUESTED,
-    REDEMPTION_REQUEST_FAILED,
+    REDEMPTION_REQUEST_ERROR,
 } from '../sagas/redemption'
 
 import { RESTORE_REDEMPTION_STATE } from "../actions"
@@ -75,7 +75,7 @@ const redemption = (state = initialState, action) => {
                 ...state,
                 redemption: action.payload.redemption,
             }
-        case REDEMPTION_REQUEST_FAILED:
+        case REDEMPTION_REQUEST_ERROR:
             return {
                 ...state,
                 requestRedemptionError: action.payload.error,

--- a/src/reducers/redemption.js
+++ b/src/reducers/redemption.js
@@ -3,6 +3,7 @@ import {
     UPDATE_TRANSACTION_AND_SIGNATURE,
     UPDATE_TX_HASH,
     UPDATE_CONFIRMATIONS,
+    SIGN_TX_ERROR,
     POLL_FOR_CONFIRMATIONS_ERROR,
     REDEMPTION_PROVE_BTC_TX_BEGIN,
     REDEMPTION_PROVE_BTC_TX_SUCCESS,
@@ -54,6 +55,11 @@ const redemption = (state = initialState, action) => {
                 ...state,
                 unsignedTransaction: action.payload.unsignedTransaction,
                 signature: action.payload.signature
+            }
+        case SIGN_TX_ERROR:
+            return {
+                ...state,
+                signTxError: action.payload.error,
             }
         case UPDATE_TX_HASH:
             return {

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -29,6 +29,8 @@ export const BTC_TX_CONFIRMED = 'BTC_TX_CONFIRMED'
 export const DEPOSIT_PROVE_BTC_TX_BEGIN = 'DEPOSIT_PROVE_BTC_TX_BEGIN'
 export const DEPOSIT_PROVE_BTC_TX_SUCCESS = 'DEPOSIT_PROVE_BTC_TX_SUCCESS'
 export const DEPOSIT_PROVE_BTC_TX_ERROR = 'DEPOSIT_PROVE_BTC_TX_ERROR'
+export const DEPOSIT_MINT_TBTC = 'DEPOSIT_MINT_TBTC'
+export const DEPOSIT_MINT_TBTC_ERROR = 'DEPOSIT_MINT_TBTC_ERROR'
 
 function* restoreState(nextStepMap, stateKey) {
     /** @type {TBTC} */
@@ -319,7 +321,17 @@ export function* autoSubmitDepositProof() {
         })
     }
 
-    yield call([deposit, deposit.mintTBTC])
+    try {
+        yield put({ type: DEPOSIT_MINT_TBTC })
+        yield call([deposit, deposit.mintTBTC])
+    } catch (error) {
+        yield put({
+            type: DEPOSIT_MINT_TBTC_ERROR,
+            payload: {
+                error: error.message,
+            }
+        })
+    }
 
     // goto
     yield put(navigateTo('/deposit/' + deposit.address + '/congratulations'))

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -256,15 +256,24 @@ export function* autoSubmitDepositProof() {
     // goto
     yield put(navigateTo('/deposit/' + deposit.address + '/prove'))
 
-    yield put({ type: DEPOSIT_PROVE_BTC_TX_BEGIN })
-    const proofTransaction = yield autoSubmission.proofTransaction
+    try {
+        yield put({ type: DEPOSIT_PROVE_BTC_TX_BEGIN })
+        const proofTransaction = yield autoSubmission.proofTransaction
 
-    yield put({
-        type: DEPOSIT_PROVE_BTC_TX_SUCCESS,
-        payload: {
-            proofTransaction,
-        }
-    })
+        yield put({
+            type: DEPOSIT_PROVE_BTC_TX_SUCCESS,
+            payload: {
+                proofTransaction,
+            }
+        })
+    } catch (error) {
+        yield put({
+            type: DEPOSIT_PROVE_BTC_TX_ERROR,
+            payload: {
+                error: error.message
+            }
+        })
+    }
 
     yield call([deposit, deposit.mintTBTC])
 

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -17,9 +17,10 @@ export const DEPOSIT_REQUEST_METAMASK_SUCCESS = 'DEPOSIT_REQUEST_METAMASK_SUCCES
 export const DEPOSIT_REQUEST_SUCCESS = 'DEPOSIT_REQUEST_SUCCESS'
 export const DEPOSIT_RESOLVED = 'DEPOSIT_RESOLVED'
 export const DEPOSIT_BTC_ADDRESS = 'DEPOSIT_BTC_ADDRESS'
-export const DEPOSIT_BTC_ADDRESS_FAILED = 'DEPOSIT_BTC_ADDRESS_FAILED'
+export const DEPOSIT_BTC_ADDRESS_ERROR = 'DEPOSIT_BTC_ADDRESS_ERROR'
 export const DEPOSIT_STATE_RESTORED = 'DEPOSIT_STATE_RESTORED'
 export const DEPOSIT_BTC_AMOUNTS = 'DEPOSIT_BTC_AMOUNTS'
+export const DEPOSIT_BTC_AMOUNTS_ERROR = 'DEPOSIT_BTC_AMOUNTS_ERROR'
 export const DEPOSIT_AUTO_SUBMIT_PROOF = 'DEPOSIT_AUTO_SUBMIT_PROOF'
 
 export const BTC_TX_MINED = 'BTC_TX_MINED'
@@ -229,23 +230,32 @@ export function* getBitcoinAddress() {
         })
     } catch (error) {
         yield put({
-            type: DEPOSIT_BTC_ADDRESS_FAILED,
+            type: DEPOSIT_BTC_ADDRESS_ERROR,
             payload: {
                 error: error.message,
             }
         })
     }
 
-    const lotInSatoshis = yield call([deposit, deposit.getSatoshiLotSize])
-    const signerFeeTbtc = yield call([deposit, deposit.getSignerFeeTBTC])
-    const signerFeeInSatoshis = signerFeeTbtc.div(tbtc.satoshisPerTbtc)
-    yield put({
-        type: DEPOSIT_BTC_AMOUNTS,
-        payload: {
-            lotInSatoshis,
-            signerFeeInSatoshis,
-        }
-    })
+    try {
+        const lotInSatoshis = yield call([deposit, deposit.getSatoshiLotSize])
+        const signerFeeTbtc = yield call([deposit, deposit.getSignerFeeTBTC])
+        const signerFeeInSatoshis = signerFeeTbtc.div(tbtc.satoshisPerTbtc)
+        yield put({
+            type: DEPOSIT_BTC_AMOUNTS,
+            payload: {
+                lotInSatoshis,
+                signerFeeInSatoshis,
+            }
+        })
+    } catch (error) {
+        yield put({
+            type: DEPOSIT_BTC_AMOUNTS_ERROR,
+            payload: {
+                error: error.message,
+            }
+        })
+    }
 
     // goto
     yield put(navigateTo('/deposit/' + deposit.address + '/pay'))

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -18,6 +18,7 @@ export const DEPOSIT_REQUEST_METAMASK_SUCCESS = 'DEPOSIT_REQUEST_METAMASK_SUCCES
 export const DEPOSIT_REQUEST_SUCCESS = 'DEPOSIT_REQUEST_SUCCESS'
 export const DEPOSIT_RESOLVED = 'DEPOSIT_RESOLVED'
 export const DEPOSIT_BTC_ADDRESS = 'DEPOSIT_BTC_ADDRESS'
+export const DEPOSIT_BTC_ADDRESS_FAILED = 'DEPOSIT_BTC_ADDRESS_FAILED'
 export const DEPOSIT_STATE_RESTORED = 'DEPOSIT_STATE_RESTORED'
 export const DEPOSIT_BTC_AMOUNTS = 'DEPOSIT_BTC_AMOUNTS'
 
@@ -191,14 +192,22 @@ export function* getBitcoinAddress() {
     /** @type Deposit */
     const deposit = yield select(state => state.deposit.deposit)
 
-    const btcAddress = yield deposit.bitcoinAddress
-
-    yield put({
-        type: DEPOSIT_BTC_ADDRESS,
-        payload: {
-            btcAddress,
-        }
-    })
+    try {
+        const btcAddress = yield deposit.bitcoinAddress
+        yield put({
+            type: DEPOSIT_BTC_ADDRESS,
+            payload: {
+                btcAddress,
+            }
+        })
+    } catch (error) {
+        yield put({
+            type: DEPOSIT_BTC_ADDRESS_FAILED,
+            payload: {
+                error: error.message,
+            }
+        })
+    }
 
     const lotInSatoshis = yield call([deposit, deposit.getSatoshiLotSize])
     const signerFeeTbtc = yield call([deposit, deposit.getSignerFeeTBTC])

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -15,6 +15,7 @@ import BN from "bn.js"
 export const DEPOSIT_REQUEST_BEGIN = 'DEPOSIT_REQUEST_BEGIN'
 export const DEPOSIT_REQUEST_METAMASK_SUCCESS = 'DEPOSIT_REQUEST_METAMASK_SUCCESS'
 export const DEPOSIT_REQUEST_SUCCESS = 'DEPOSIT_REQUEST_SUCCESS'
+export const DEPOSIT_REQUEST_ERROR = 'DEPOSIT_REQUEST_ERROR'
 export const DEPOSIT_RESOLVED = 'DEPOSIT_RESOLVED'
 export const DEPOSIT_BTC_ADDRESS = 'DEPOSIT_BTC_ADDRESS'
 export const DEPOSIT_BTC_ADDRESS_ERROR = 'DEPOSIT_BTC_ADDRESS_ERROR'
@@ -189,7 +190,12 @@ export function* requestADeposit() {
         deposit = yield call([tbtc.Deposit, tbtc.Deposit.withSatoshiLotSize], new BN(1000000))
     } catch (err) {
         if (err.message.includes(METAMASK_TX_DENIED_ERROR)) return
-        throw err
+        yield put({
+            type: DEPOSIT_REQUEST_ERROR,
+            payload: {
+                error: err.message,
+            }
+        })
     }
     yield put({ type: DEPOSIT_REQUEST_METAMASK_SUCCESS })
 

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -198,6 +198,7 @@ export function* requestADeposit() {
                 error: err.message,
             }
         })
+        return
     }
     yield put({ type: DEPOSIT_REQUEST_METAMASK_SUCCESS })
 
@@ -243,6 +244,7 @@ export function* getBitcoinAddress() {
                 error: error.message,
             }
         })
+        return
     }
 
     try {
@@ -263,6 +265,7 @@ export function* getBitcoinAddress() {
                 error: error.message,
             }
         })
+        return
     }
 
     // goto
@@ -302,6 +305,7 @@ export function* autoSubmitDepositProof() {
                 error: error.message,
             }
         })
+        return
     }
 
     // wait a certain number of confirmations on this step
@@ -328,6 +332,7 @@ export function* autoSubmitDepositProof() {
                 error: error.message
             }
         })
+        return
     }
 
     // emit a notification
@@ -354,6 +359,7 @@ export function* autoSubmitDepositProof() {
                 error: error.message
             }
         })
+        return
     }
 
     try {
@@ -366,6 +372,7 @@ export function* autoSubmitDepositProof() {
                 error: error.message,
             }
         })
+        return
     }
 
     // goto

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -27,6 +27,7 @@ export const DEPOSIT_AUTO_SUBMIT_PROOF = 'DEPOSIT_AUTO_SUBMIT_PROOF'
 export const BTC_TX_MINED = 'BTC_TX_MINED'
 export const BTC_TX_CONFIRMED_WAIT = 'BTC_TX_CONFIRMED_WAIT'
 export const BTC_TX_CONFIRMED = 'BTC_TX_CONFIRMED'
+export const BTC_TX_CONFIRMING_ERROR = 'BTC_TX_CONFIRMING_ERROR'
 
 export const DEPOSIT_PROVE_BTC_TX_BEGIN = 'DEPOSIT_PROVE_BTC_TX_BEGIN'
 export const DEPOSIT_PROVE_BTC_TX_SUCCESS = 'DEPOSIT_PROVE_BTC_TX_SUCCESS'
@@ -303,13 +304,23 @@ export function* autoSubmitDepositProof() {
     // goto
     yield put(navigateTo('/deposit/' + deposit.address + '/pay/confirming'))
 
-    yield autoSubmission.fundingConfirmations
+    try {
+        const confirmations = yield autoSubmission.fundingConfirmations
 
-    // when it's finally sufficiently confirmed, dispatch the txid
-    yield put({
-        type: BTC_TX_CONFIRMED
-        // TODO Which transaction?
-    })
+        yield put({
+            type: BTC_TX_CONFIRMED,
+            payload: {
+                btcConfirmedTxID: confirmations.transaction.transactionID,
+            }
+        })
+    } catch (error) {
+        yield put({
+            type: BTC_TX_CONFIRMING_ERROR,
+            payload: {
+                error: error.message
+            }
+        })
+    }
 
     // emit a notification
     // FIXME This should be a reducer on BTC_TX_CONFIRMED.

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -164,6 +164,9 @@ export function* onStateRestored(depositState) {
         case tbtc.Deposit.State.AWAITING_BTC_FUNDING_PROOF:
             yield* autoSubmitDepositProof()
             break
+        case tbtc.Deposit.State.AWAITING_WITHDRAWAL_SIGNATURE:
+            yield* resumeRedemption()
+            break
         default:
             // noop
             break

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -4,7 +4,6 @@ import {
     restoreDepositState,
     restoreRedemptionState,
     requestADeposit,
-    autoSubmitDepositProof 
 } from './deposit'
 
 import {
@@ -16,7 +15,6 @@ import {
     RESTORE_DEPOSIT_STATE,
     RESTORE_REDEMPTION_STATE,
     REQUEST_A_DEPOSIT,
-    AUTO_SUBMIT_DEPOSIT_PROOF,
     SAVE_ADDRESSES,
     REQUEST_REDEMPTION,
     RESUME_REDEMPTION,
@@ -26,7 +24,6 @@ export default function* () {
     yield takeLatest(RESTORE_DEPOSIT_STATE, restoreDepositState)
     yield takeLatest(RESTORE_REDEMPTION_STATE, restoreRedemptionState)
     yield takeLatest(REQUEST_A_DEPOSIT, requestADeposit)
-    yield takeLatest(AUTO_SUBMIT_DEPOSIT_PROOF, autoSubmitDepositProof)
     yield takeLatest(SAVE_ADDRESSES, saveAddresses)
     yield takeLatest(REQUEST_REDEMPTION, requestRedemption)
     yield takeLatest(RESUME_REDEMPTION, resumeRedemption)

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -9,7 +9,6 @@ import {
 import {
     saveAddresses,
     requestRedemption,
-    resumeRedemption,
 } from './redemption'
 import {
     RESTORE_DEPOSIT_STATE,
@@ -17,7 +16,6 @@ import {
     REQUEST_A_DEPOSIT,
     SAVE_ADDRESSES,
     REQUEST_REDEMPTION,
-    RESUME_REDEMPTION,
 } from '../actions'
 
 export default function* () {
@@ -26,5 +24,4 @@ export default function* () {
     yield takeLatest(REQUEST_A_DEPOSIT, requestADeposit)
     yield takeLatest(SAVE_ADDRESSES, saveAddresses)
     yield takeLatest(REQUEST_REDEMPTION, requestRedemption)
-    yield takeLatest(RESUME_REDEMPTION, resumeRedemption)
 }

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -4,7 +4,6 @@ import {
     restoreDepositState,
     restoreRedemptionState,
     requestADeposit,
-    getBitcoinAddress,
     autoSubmitDepositProof 
 } from './deposit'
 
@@ -17,7 +16,6 @@ import {
     RESTORE_DEPOSIT_STATE,
     RESTORE_REDEMPTION_STATE,
     REQUEST_A_DEPOSIT,
-    GET_BITCOIN_ADDRESS,
     AUTO_SUBMIT_DEPOSIT_PROOF,
     SAVE_ADDRESSES,
     REQUEST_REDEMPTION,
@@ -28,7 +26,6 @@ export default function* () {
     yield takeLatest(RESTORE_DEPOSIT_STATE, restoreDepositState)
     yield takeLatest(RESTORE_REDEMPTION_STATE, restoreRedemptionState)
     yield takeLatest(REQUEST_A_DEPOSIT, requestADeposit)
-    yield takeLatest(GET_BITCOIN_ADDRESS, getBitcoinAddress)
     yield takeLatest(AUTO_SUBMIT_DEPOSIT_PROOF, autoSubmitDepositProof)
     yield takeLatest(SAVE_ADDRESSES, saveAddresses)
     yield takeLatest(REQUEST_REDEMPTION, requestRedemption)

--- a/src/sagas/redemption.js
+++ b/src/sagas/redemption.js
@@ -109,9 +109,18 @@ function* runRedemption(redemption) {
 
     yield put(navigateTo('/deposit/' + depositAddress + '/redemption/confirming'))
 
-    yield autoSubmission.confirmations
+    try {
+        yield autoSubmission.confirmations
 
-    yield put(navigateTo('/deposit/' + depositAddress + '/redemption/prove'))
+        yield put(navigateTo('/deposit/' + depositAddress + '/redemption/prove'))
+    } catch (error) {
+        yield put({
+            type: POLL_FOR_CONFIRMATIONS_ERROR,
+            payload: {
+                error: error.message,
+            }
+        })
+    }
 
     try {
         yield put({ type: REDEMPTION_PROVE_BTC_TX_BEGIN })

--- a/src/sagas/redemption.js
+++ b/src/sagas/redemption.js
@@ -14,7 +14,7 @@ export const UPDATE_TX_HASH = 'UPDATE_TX_HASH'
 export const UPDATE_CONFIRMATIONS = 'UPDATE_CONFIRMATIONS'
 export const POLL_FOR_CONFIRMATIONS_ERROR = 'POLL_FOR_CONFIRMATIONS_ERROR'
 export const REDEMPTION_REQUESTED = 'REDEMPTION_REQUESTED'
-export const REDEMPTION_REQUEST_FAILED = 'REDEMPTION_REQUEST_FAILED'
+export const REDEMPTION_REQUEST_ERROR = 'REDEMPTION_REQUEST_ERROR'
 export const REDEMPTION_PROVE_BTC_TX_BEGIN = 'REDEMPTION_PROVE_BTC_TX_BEGIN'
 export const REDEMPTION_PROVE_BTC_TX_SUCCESS = 'REDEMPTION_PROVE_BTC_TX_SUCCESS'
 export const REDEMPTION_PROVE_BTC_TX_ERROR = 'REDEMPTION_PROVE_BTC_TX_ERROR'
@@ -59,7 +59,7 @@ export function* requestRedemption() {
         yield* runRedemption(redemption)
     } catch (error) {
         yield put({
-            type: REDEMPTION_REQUEST_FAILED,
+            type: REDEMPTION_REQUEST_ERROR,
             payload: {
                 error: error.message,
             }
@@ -88,7 +88,7 @@ export function* resumeRedemption() {
         yield* runRedemption(redemption)
     } catch (error) {
         yield put({
-            type: REDEMPTION_REQUEST_FAILED,
+            type: REDEMPTION_REQUEST_ERROR,
             payload: {
                 error: error.message,
             }

--- a/src/sagas/redemption.js
+++ b/src/sagas/redemption.js
@@ -33,6 +33,7 @@ export function* saveAddresses({ payload }) {
         type: DEPOSIT_RESOLVED,
         payload: {
             deposit,
+            btcNetwork: tbtc.config.bitcoinNetwork,
         }
     })
 

--- a/src/sagas/redemption.js
+++ b/src/sagas/redemption.js
@@ -13,7 +13,8 @@ export const UPDATE_TRANSACTION_AND_SIGNATURE = 'UPDATE_TRANSACTION_AND_SIGNATUR
 export const UPDATE_TX_HASH = 'UPDATE_TX_HASH'
 export const UPDATE_CONFIRMATIONS = 'UPDATE_CONFIRMATIONS'
 export const POLL_FOR_CONFIRMATIONS_ERROR = 'POLL_FOR_CONFIRMATIONS_ERROR'
-export const REDEMPTION_REQUEST_SUCCESS = 'REDEMPTION_REQUEST_SUCCESS'
+export const REDEMPTION_REQUESTED = 'REDEMPTION_REQUESTED'
+export const REDEMPTION_REQUEST_FAILED = 'REDEMPTION_REQUEST_FAILED'
 export const REDEMPTION_PROVE_BTC_TX_BEGIN = 'REDEMPTION_PROVE_BTC_TX_BEGIN'
 export const REDEMPTION_PROVE_BTC_TX_SUCCESS = 'REDEMPTION_PROVE_BTC_TX_SUCCESS'
 export const REDEMPTION_PROVE_BTC_TX_ERROR = 'REDEMPTION_PROVE_BTC_TX_ERROR'
@@ -45,16 +46,25 @@ export function* requestRedemption() {
     /** @type string */
     const btcAddress = yield select(state => state.redemption.btcAddress)
 
-    /** @type {Redemption} */
-    const redemption = yield call([deposit, deposit.requestRedemption], btcAddress)
-    yield put({
-        type: REDEMPTION_REQUEST_SUCCESS,
-        payload: {
-            redemption
-        }
-    })
+    try {
+        /** @type {Redemption} */
+        const redemption = yield call([deposit, deposit.requestRedemption], btcAddress)
+        yield put({
+            type: REDEMPTION_REQUESTED,
+            payload: {
+                redemption
+            }
+        })
 
-    yield* runRedemption(redemption)
+        yield* runRedemption(redemption)
+    } catch (error) {
+        yield put({
+            type: REDEMPTION_REQUEST_FAILED,
+            payload: {
+                error: error.message,
+            }
+        })
+    }
 }
 
 export function* resumeRedemption() {
@@ -68,7 +78,7 @@ export function* resumeRedemption() {
     const redemption = yield call([deposit, deposit.getCurrentRedemption])
 
     yield put({
-        type: REDEMPTION_REQUEST_SUCCESS,
+        type: REDEMPTION_REQUESTED,
         payload: {
             redemption
         }

--- a/src/sagas/redemption.js
+++ b/src/sagas/redemption.js
@@ -122,6 +122,7 @@ function* runRedemption(redemption) {
                 error: error.message,
             }
         })
+        return
     }
 
     try {
@@ -135,6 +136,7 @@ function* runRedemption(redemption) {
                 error: error.message,
             }
         })
+        return
     }
 
     try {

--- a/src/sagas/redemption.js
+++ b/src/sagas/redemption.js
@@ -75,16 +75,25 @@ export function* resumeRedemption() {
         return // just one at a time please; FIXME should be handled better
     }
 
-    const redemption = yield call([deposit, deposit.getCurrentRedemption])
+    try {
+        const redemption = yield call([deposit, deposit.getCurrentRedemption])
 
-    yield put({
-        type: REDEMPTION_REQUESTED,
-        payload: {
-            redemption
-        }
-    })
+        yield put({
+            type: REDEMPTION_REQUESTED,
+            payload: {
+                redemption
+            }
+        })
 
-    yield* runRedemption(redemption)
+        yield* runRedemption(redemption)
+    } catch (error) {
+        yield put({
+            type: REDEMPTION_REQUEST_FAILED,
+            payload: {
+                error: error.message,
+            }
+        })
+    }
 }
 
 /**

--- a/src/sagas/redemption.js
+++ b/src/sagas/redemption.js
@@ -11,6 +11,7 @@ import { DEPOSIT_RESOLVED } from "./deposit"
 export const UPDATE_ADDRESSES = 'UPDATE_ADDRESSES'
 export const UPDATE_TRANSACTION_AND_SIGNATURE = 'UPDATE_TRANSACTION_AND_SIGNATURE'
 export const UPDATE_TX_HASH = 'UPDATE_TX_HASH'
+export const SIGN_TX_ERROR = 'SIGN_TX_ERROR'
 export const UPDATE_CONFIRMATIONS = 'UPDATE_CONFIRMATIONS'
 export const POLL_FOR_CONFIRMATIONS_ERROR = 'POLL_FOR_CONFIRMATIONS_ERROR'
 export const REDEMPTION_REQUESTED = 'REDEMPTION_REQUESTED'
@@ -105,9 +106,18 @@ function* runRedemption(redemption) {
 
     yield put(navigateTo('/deposit/' + depositAddress + '/redemption/signing'))
 
-    yield autoSubmission.broadcastTransactionID
+    try {
+        yield autoSubmission.broadcastTransactionID
 
-    yield put(navigateTo('/deposit/' + depositAddress + '/redemption/confirming'))
+        yield put(navigateTo('/deposit/' + depositAddress + '/redemption/confirming'))
+    } catch (error) {
+        yield put({
+            type: SIGN_TX_ERROR,
+            payload: {
+                error: error.message,
+            }
+        })
+    }
 
     try {
         yield autoSubmission.confirmations

--- a/src/sagas/redemption.js
+++ b/src/sagas/redemption.js
@@ -9,10 +9,8 @@ import { navigateTo } from '../lib/router/actions'
 import { DEPOSIT_RESOLVED } from "./deposit"
 
 export const UPDATE_ADDRESSES = 'UPDATE_ADDRESSES'
-export const UPDATE_TRANSACTION_AND_SIGNATURE = 'UPDATE_TRANSACTION_AND_SIGNATURE'
 export const UPDATE_TX_HASH = 'UPDATE_TX_HASH'
 export const SIGN_TX_ERROR = 'SIGN_TX_ERROR'
-export const UPDATE_CONFIRMATIONS = 'UPDATE_CONFIRMATIONS'
 export const POLL_FOR_CONFIRMATIONS_ERROR = 'POLL_FOR_CONFIRMATIONS_ERROR'
 export const REDEMPTION_REQUESTED = 'REDEMPTION_REQUESTED'
 export const REDEMPTION_REQUEST_ERROR = 'REDEMPTION_REQUEST_ERROR'
@@ -107,7 +105,14 @@ function* runRedemption(redemption) {
     yield put(navigateTo('/deposit/' + depositAddress + '/redemption/signing'))
 
     try {
-        yield autoSubmission.broadcastTransactionID
+        const txHash = yield autoSubmission.broadcastTransactionID
+
+        yield put({
+            type: UPDATE_TX_HASH,
+            payload: {
+                txHash,
+            },
+        })
 
         yield put(navigateTo('/deposit/' + depositAddress + '/redemption/confirming'))
     } catch (error) {

--- a/src/wrappers/loadable.js
+++ b/src/wrappers/loadable.js
@@ -14,7 +14,7 @@ function LoadableBase({ children, restoreDepositState, restoreRedemptionState, r
     // Wait for web3 connected
     const { active: web3Active } = useWeb3React()
     const { address } = useParams()
-    const depositStateRestored = useSelector((state) => state[restorer].stateRestored)
+    const depositStateRestored = useSelector((state) => state[restorer].isStateReady)
     
     useEffect(() => {
         if(web3Active && address && ! depositStateRestored) {


### PR DESCRIPTION
This PR tries to catch most of the errors that can emerge during both the deposit and redemption flows and surface these messages to the UI. While it doesn't tackle any new UX (like a button to retry) yet, hopefully making these errors visible can empower users maybe refresh the page. (New UX will be handled in a separate PR).

There is also a little bit of refactoring here to remove actions living in components that should be state driven. There is a new saga called `onStateRestored` that runs after the deposit state is successfully restored and triggers new actions based on the given deposit state.

Lastly, there is a fix (984eb3c and 3176082) here for a [regression](https://github.com/keep-network/tbtc-dapp/pull/224#issuecomment-652140166) introduced in #224.

Addresses part 2 of #218.

-----
TODO
- [x] More errors to handle? (Errors getting `fundingTransaction` or `broadcastTransactionId` during `autoSubmit`?)
- [x] More testing