### PR TITLE
Release: 0.16.5-rc (Ropsten)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2041,9 +2041,9 @@
             }
         },
         "@keep-network/tbtc.js": {
-            "version": "0.16.0-rc.1",
-            "resolved": "https://registry.npmjs.org/@keep-network/tbtc.js/-/tbtc.js-0.16.0-rc.1.tgz",
-            "integrity": "sha512-PJRWLYzx1NszGXMn8/4rtBR4BCPXG+4yYd9nzEghZw5ZdRWXEqNnG3ZauglelTWiRjQSu7P18BTYNWACxdnwsQ==",
+            "version": "0.16.0-rc.2",
+            "resolved": "https://registry.npmjs.org/@keep-network/tbtc.js/-/tbtc.js-0.16.0-rc.2.tgz",
+            "integrity": "sha512-pl4O68aCRzafLVHXuE9KX2wef4o4mFZtntpAkHhJKWzz+jYqycNjDsu6dqwQLJFNjwsL43myPDE4DYjcJ9yoxQ==",
             "requires": {
                 "@keep-network/keep-ecdsa": ">1.1.2-rc <1.1.2",
                 "@keep-network/tbtc": ">1.0.3-rc <1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "tbtc-dapp",
-    "version": "0.16.4-rc",
+    "version": "0.16.5-rc",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1082,6 +1082,520 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
+        "@celo/contractkit": {
+            "version": "0.3.8",
+            "resolved": "https://registry.npmjs.org/@celo/contractkit/-/contractkit-0.3.8.tgz",
+            "integrity": "sha512-lEXciI3tYnDKNdyazW6etR/ZFm0wrNlX1OxNgzv5D8HCPJcFSUF3Bi4fYtL/Ocx2oHNpK4k3eDZ6aj+ZbkRC+Q==",
+            "requires": {
+                "@celo/utils": "0.1.11",
+                "@ledgerhq/hw-app-eth": "^5.11.0",
+                "@ledgerhq/hw-transport": "^5.11.0",
+                "@types/debug": "^4.1.5",
+                "bignumber.js": "^9.0.0",
+                "cross-fetch": "3.0.4",
+                "debug": "^4.1.1",
+                "eth-lib": "^0.2.8",
+                "ethereumjs-util": "^5.2.0",
+                "fp-ts": "2.1.1",
+                "io-ts": "2.0.1",
+                "web3": "1.2.4",
+                "web3-core": "1.2.4",
+                "web3-core-helpers": "1.2.4",
+                "web3-eth-abi": "1.2.4",
+                "web3-eth-contract": "1.2.4",
+                "web3-utils": "1.2.4"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "12.12.48",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.48.tgz",
+                    "integrity": "sha512-m3Nmo/YaDUfYzdCQlxjF5pIy7TNyDTAJhIa//xtHcF0dlgYIBKULKnmloCPtByDxtZXrWV8Pge1AKT6/lRvVWg=="
+                },
+                "eth-lib": {
+                    "version": "0.2.8",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+                    "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+                    "requires": {
+                        "bn.js": "^4.11.6",
+                        "elliptic": "^6.4.0",
+                        "xhr-request-promise": "^0.1.2"
+                    }
+                },
+                "ethereumjs-util": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+                    "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+                    "requires": {
+                        "bn.js": "^4.11.0",
+                        "create-hash": "^1.1.2",
+                        "ethjs-util": "^0.1.3",
+                        "keccak": "^1.0.2",
+                        "rlp": "^2.0.0",
+                        "safe-buffer": "^5.1.1",
+                        "secp256k1": "^3.0.1"
+                    }
+                },
+                "ethers": {
+                    "version": "4.0.0-beta.3",
+                    "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
+                    "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+                    "requires": {
+                        "@types/node": "^10.3.2",
+                        "aes-js": "3.0.0",
+                        "bn.js": "^4.4.0",
+                        "elliptic": "6.3.3",
+                        "hash.js": "1.1.3",
+                        "js-sha3": "0.5.7",
+                        "scrypt-js": "2.0.3",
+                        "setimmediate": "1.0.4",
+                        "uuid": "2.0.1",
+                        "xmlhttprequest": "1.8.0"
+                    },
+                    "dependencies": {
+                        "@types/node": {
+                            "version": "10.17.26",
+                            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+                            "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
+                        },
+                        "elliptic": {
+                            "version": "6.3.3",
+                            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+                            "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+                            "requires": {
+                                "bn.js": "^4.4.0",
+                                "brorand": "^1.0.1",
+                                "hash.js": "^1.0.0",
+                                "inherits": "^2.0.1"
+                            }
+                        }
+                    }
+                },
+                "hash.js": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+                    "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "minimalistic-assert": "^1.0.0"
+                    }
+                },
+                "js-sha3": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+                    "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+                },
+                "keccak": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+                    "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+                    "requires": {
+                        "bindings": "^1.2.1",
+                        "inherits": "^2.0.3",
+                        "nan": "^2.2.1",
+                        "safe-buffer": "^5.1.0"
+                    }
+                },
+                "scrypt-js": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+                    "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+                },
+                "uuid": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+                    "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+                },
+                "web3": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.4.tgz",
+                    "integrity": "sha512-xPXGe+w0x0t88Wj+s/dmAdASr3O9wmA9mpZRtixGZxmBexAF0MjfqYM+MS4tVl5s11hMTN3AZb8cDD4VLfC57A==",
+                    "requires": {
+                        "@types/node": "^12.6.1",
+                        "web3-bzz": "1.2.4",
+                        "web3-core": "1.2.4",
+                        "web3-eth": "1.2.4",
+                        "web3-eth-personal": "1.2.4",
+                        "web3-net": "1.2.4",
+                        "web3-shh": "1.2.4",
+                        "web3-utils": "1.2.4"
+                    }
+                },
+                "web3-bzz": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.4.tgz",
+                    "integrity": "sha512-MqhAo/+0iQSMBtt3/QI1rU83uvF08sYq8r25+OUZ+4VtihnYsmkkca+rdU0QbRyrXY2/yGIpI46PFdh0khD53A==",
+                    "requires": {
+                        "@types/node": "^10.12.18",
+                        "got": "9.6.0",
+                        "swarm-js": "0.1.39",
+                        "underscore": "1.9.1"
+                    },
+                    "dependencies": {
+                        "@types/node": {
+                            "version": "10.17.26",
+                            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+                            "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
+                        }
+                    }
+                },
+                "web3-core": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.4.tgz",
+                    "integrity": "sha512-CHc27sMuET2cs1IKrkz7xzmTdMfZpYswe7f0HcuyneTwS1yTlTnHyqjAaTy0ZygAb/x4iaVox+Gvr4oSAqSI+A==",
+                    "requires": {
+                        "@types/bignumber.js": "^5.0.0",
+                        "@types/bn.js": "^4.11.4",
+                        "@types/node": "^12.6.1",
+                        "web3-core-helpers": "1.2.4",
+                        "web3-core-method": "1.2.4",
+                        "web3-core-requestmanager": "1.2.4",
+                        "web3-utils": "1.2.4"
+                    }
+                },
+                "web3-core-helpers": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.4.tgz",
+                    "integrity": "sha512-U7wbsK8IbZvF3B7S+QMSNP0tni/6VipnJkB0tZVEpHEIV2WWeBHYmZDnULWcsS/x/jn9yKhJlXIxWGsEAMkjiw==",
+                    "requires": {
+                        "underscore": "1.9.1",
+                        "web3-eth-iban": "1.2.4",
+                        "web3-utils": "1.2.4"
+                    }
+                },
+                "web3-core-method": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.4.tgz",
+                    "integrity": "sha512-8p9kpL7di2qOVPWgcM08kb+yKom0rxRCMv6m/K+H+yLSxev9TgMbCgMSbPWAHlyiF3SJHw7APFKahK5Z+8XT5A==",
+                    "requires": {
+                        "underscore": "1.9.1",
+                        "web3-core-helpers": "1.2.4",
+                        "web3-core-promievent": "1.2.4",
+                        "web3-core-subscriptions": "1.2.4",
+                        "web3-utils": "1.2.4"
+                    }
+                },
+                "web3-core-promievent": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz",
+                    "integrity": "sha512-gEUlm27DewUsfUgC3T8AxkKi8Ecx+e+ZCaunB7X4Qk3i9F4C+5PSMGguolrShZ7Zb6717k79Y86f3A00O0VAZw==",
+                    "requires": {
+                        "any-promise": "1.3.0",
+                        "eventemitter3": "3.1.2"
+                    }
+                },
+                "web3-core-requestmanager": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.4.tgz",
+                    "integrity": "sha512-eZJDjyNTDtmSmzd3S488nR/SMJtNnn/GuwxnMh3AzYCqG3ZMfOylqTad2eYJPvc2PM5/Gj1wAMQcRpwOjjLuPg==",
+                    "requires": {
+                        "underscore": "1.9.1",
+                        "web3-core-helpers": "1.2.4",
+                        "web3-providers-http": "1.2.4",
+                        "web3-providers-ipc": "1.2.4",
+                        "web3-providers-ws": "1.2.4"
+                    }
+                },
+                "web3-core-subscriptions": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.4.tgz",
+                    "integrity": "sha512-3D607J2M8ymY9V+/WZq4MLlBulwCkwEjjC2U+cXqgVO1rCyVqbxZNCmHyNYHjDDCxSEbks9Ju5xqJxDSxnyXEw==",
+                    "requires": {
+                        "eventemitter3": "3.1.2",
+                        "underscore": "1.9.1",
+                        "web3-core-helpers": "1.2.4"
+                    }
+                },
+                "web3-eth": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.4.tgz",
+                    "integrity": "sha512-+j+kbfmZsbc3+KJpvHM16j1xRFHe2jBAniMo1BHKc3lho6A8Sn9Buyut6odubguX2AxoRArCdIDCkT9hjUERpA==",
+                    "requires": {
+                        "underscore": "1.9.1",
+                        "web3-core": "1.2.4",
+                        "web3-core-helpers": "1.2.4",
+                        "web3-core-method": "1.2.4",
+                        "web3-core-subscriptions": "1.2.4",
+                        "web3-eth-abi": "1.2.4",
+                        "web3-eth-accounts": "1.2.4",
+                        "web3-eth-contract": "1.2.4",
+                        "web3-eth-ens": "1.2.4",
+                        "web3-eth-iban": "1.2.4",
+                        "web3-eth-personal": "1.2.4",
+                        "web3-net": "1.2.4",
+                        "web3-utils": "1.2.4"
+                    }
+                },
+                "web3-eth-abi": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.4.tgz",
+                    "integrity": "sha512-8eLIY4xZKoU3DSVu1pORluAw9Ru0/v4CGdw5so31nn+7fR8zgHMgwbFe0aOqWQ5VU42PzMMXeIJwt4AEi2buFg==",
+                    "requires": {
+                        "ethers": "4.0.0-beta.3",
+                        "underscore": "1.9.1",
+                        "web3-utils": "1.2.4"
+                    }
+                },
+                "web3-eth-accounts": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.4.tgz",
+                    "integrity": "sha512-04LzT/UtWmRFmi4hHRewP5Zz43fWhuHiK5XimP86sUQodk/ByOkXQ3RoXyGXFMNoRxdcAeRNxSfA2DpIBc9xUw==",
+                    "requires": {
+                        "@web3-js/scrypt-shim": "^0.1.0",
+                        "any-promise": "1.3.0",
+                        "crypto-browserify": "3.12.0",
+                        "eth-lib": "0.2.7",
+                        "ethereumjs-common": "^1.3.2",
+                        "ethereumjs-tx": "^2.1.1",
+                        "underscore": "1.9.1",
+                        "uuid": "3.3.2",
+                        "web3-core": "1.2.4",
+                        "web3-core-helpers": "1.2.4",
+                        "web3-core-method": "1.2.4",
+                        "web3-utils": "1.2.4"
+                    },
+                    "dependencies": {
+                        "eth-lib": {
+                            "version": "0.2.7",
+                            "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                            "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                            "requires": {
+                                "bn.js": "^4.11.6",
+                                "elliptic": "^6.4.0",
+                                "xhr-request-promise": "^0.1.2"
+                            }
+                        },
+                        "uuid": {
+                            "version": "3.3.2",
+                            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+                            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+                        }
+                    }
+                },
+                "web3-eth-contract": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.4.tgz",
+                    "integrity": "sha512-b/9zC0qjVetEYnzRA1oZ8gF1OSSUkwSYi5LGr4GeckLkzXP7osEnp9lkO/AQcE4GpG+l+STnKPnASXJGZPgBRQ==",
+                    "requires": {
+                        "@types/bn.js": "^4.11.4",
+                        "underscore": "1.9.1",
+                        "web3-core": "1.2.4",
+                        "web3-core-helpers": "1.2.4",
+                        "web3-core-method": "1.2.4",
+                        "web3-core-promievent": "1.2.4",
+                        "web3-core-subscriptions": "1.2.4",
+                        "web3-eth-abi": "1.2.4",
+                        "web3-utils": "1.2.4"
+                    }
+                },
+                "web3-eth-ens": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.4.tgz",
+                    "integrity": "sha512-g8+JxnZlhdsCzCS38Zm6R/ngXhXzvc3h7bXlxgKU4coTzLLoMpgOAEz71GxyIJinWTFbLXk/WjNY0dazi9NwVw==",
+                    "requires": {
+                        "eth-ens-namehash": "2.0.8",
+                        "underscore": "1.9.1",
+                        "web3-core": "1.2.4",
+                        "web3-core-helpers": "1.2.4",
+                        "web3-core-promievent": "1.2.4",
+                        "web3-eth-abi": "1.2.4",
+                        "web3-eth-contract": "1.2.4",
+                        "web3-utils": "1.2.4"
+                    }
+                },
+                "web3-eth-iban": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.4.tgz",
+                    "integrity": "sha512-D9HIyctru/FLRpXakRwmwdjb5bWU2O6UE/3AXvRm6DCOf2e+7Ve11qQrPtaubHfpdW3KWjDKvlxV9iaFv/oTMQ==",
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "web3-utils": "1.2.4"
+                    }
+                },
+                "web3-eth-personal": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.4.tgz",
+                    "integrity": "sha512-5Russ7ZECwHaZXcN3DLuLS7390Vzgrzepl4D87SD6Sn1DHsCZtvfdPIYwoTmKNp69LG3mORl7U23Ga5YxqkICw==",
+                    "requires": {
+                        "@types/node": "^12.6.1",
+                        "web3-core": "1.2.4",
+                        "web3-core-helpers": "1.2.4",
+                        "web3-core-method": "1.2.4",
+                        "web3-net": "1.2.4",
+                        "web3-utils": "1.2.4"
+                    }
+                },
+                "web3-net": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.4.tgz",
+                    "integrity": "sha512-wKOsqhyXWPSYTGbp7ofVvni17yfRptpqoUdp3SC8RAhDmGkX6irsiT9pON79m6b3HUHfLoBilFQyt/fTUZOf7A==",
+                    "requires": {
+                        "web3-core": "1.2.4",
+                        "web3-core-method": "1.2.4",
+                        "web3-utils": "1.2.4"
+                    }
+                },
+                "web3-providers-http": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.4.tgz",
+                    "integrity": "sha512-dzVCkRrR/cqlIrcrWNiPt9gyt0AZTE0J+MfAu9rR6CyIgtnm1wFUVVGaxYRxuTGQRO4Dlo49gtoGwaGcyxqiTw==",
+                    "requires": {
+                        "web3-core-helpers": "1.2.4",
+                        "xhr2-cookies": "1.1.0"
+                    }
+                },
+                "web3-providers-ipc": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.4.tgz",
+                    "integrity": "sha512-8J3Dguffin51gckTaNrO3oMBo7g+j0UNk6hXmdmQMMNEtrYqw4ctT6t06YOf9GgtOMjSAc1YEh3LPrvgIsR7og==",
+                    "requires": {
+                        "oboe": "2.1.4",
+                        "underscore": "1.9.1",
+                        "web3-core-helpers": "1.2.4"
+                    }
+                },
+                "web3-providers-ws": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.4.tgz",
+                    "integrity": "sha512-F/vQpDzeK+++oeeNROl1IVTufFCwCR2hpWe5yRXN0ApLwHqXrMI7UwQNdJ9iyibcWjJf/ECbauEEQ8CHgE+MYQ==",
+                    "requires": {
+                        "@web3-js/websocket": "^1.0.29",
+                        "underscore": "1.9.1",
+                        "web3-core-helpers": "1.2.4"
+                    }
+                },
+                "web3-shh": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.4.tgz",
+                    "integrity": "sha512-z+9SCw0dE+69Z/Hv8809XDbLj7lTfEv9Sgu8eKEIdGntZf4v7ewj5rzN5bZZSz8aCvfK7Y6ovz1PBAu4QzS4IQ==",
+                    "requires": {
+                        "web3-core": "1.2.4",
+                        "web3-core-method": "1.2.4",
+                        "web3-core-subscriptions": "1.2.4",
+                        "web3-net": "1.2.4"
+                    }
+                },
+                "web3-utils": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.4.tgz",
+                    "integrity": "sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==",
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "eth-lib": "0.2.7",
+                        "ethereum-bloom-filters": "^1.0.6",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randombytes": "^2.1.0",
+                        "underscore": "1.9.1",
+                        "utf8": "3.0.0"
+                    },
+                    "dependencies": {
+                        "eth-lib": {
+                            "version": "0.2.7",
+                            "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                            "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                            "requires": {
+                                "bn.js": "^4.11.6",
+                                "elliptic": "^6.4.0",
+                                "xhr-request-promise": "^0.1.2"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "@celo/utils": {
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/@celo/utils/-/utils-0.1.11.tgz",
+            "integrity": "sha512-i3oK1guBxH89AEBaVA1d5CHnANehL36gPIcSpPBWiYZrKTGGVvbwNmVoaDwaKFXih0N22vXQAf2Rul8w5VzC3w==",
+            "requires": {
+                "@umpirsky/country-list": "git://github.com/umpirsky/country-list.git#05fda51",
+                "bigi": "^1.1.0",
+                "bignumber.js": "^9.0.0",
+                "bip32": "2.0.5",
+                "bip39": "3.0.2",
+                "bls12377js": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
+                "bn.js": "4.11.8",
+                "buffer-reverse": "^1.0.1",
+                "country-data": "^0.0.31",
+                "crypto-js": "^3.1.9-1",
+                "elliptic": "^6.4.1",
+                "ethereumjs-util": "^5.2.0",
+                "futoin-hkdf": "^1.0.3",
+                "google-libphonenumber": "^3.2.4",
+                "keccak256": "^1.0.0",
+                "lodash": "^4.17.14",
+                "numeral": "^2.0.6",
+                "web3-utils": "1.2.4"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "11.11.6",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+                    "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+                },
+                "bip39": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.2.tgz",
+                    "integrity": "sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==",
+                    "requires": {
+                        "@types/node": "11.11.6",
+                        "create-hash": "^1.1.0",
+                        "pbkdf2": "^3.0.9",
+                        "randombytes": "^2.0.1"
+                    }
+                },
+                "eth-lib": {
+                    "version": "0.2.7",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "requires": {
+                        "bn.js": "^4.11.6",
+                        "elliptic": "^6.4.0",
+                        "xhr-request-promise": "^0.1.2"
+                    }
+                },
+                "ethereumjs-util": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+                    "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+                    "requires": {
+                        "bn.js": "^4.11.0",
+                        "create-hash": "^1.1.2",
+                        "ethjs-util": "^0.1.3",
+                        "keccak": "^1.0.2",
+                        "rlp": "^2.0.0",
+                        "safe-buffer": "^5.1.1",
+                        "secp256k1": "^3.0.1"
+                    }
+                },
+                "keccak": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+                    "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+                    "requires": {
+                        "bindings": "^1.2.1",
+                        "inherits": "^2.0.3",
+                        "nan": "^2.2.1",
+                        "safe-buffer": "^5.1.0"
+                    }
+                },
+                "web3-utils": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.4.tgz",
+                    "integrity": "sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==",
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "eth-lib": "0.2.7",
+                        "ethereum-bloom-filters": "^1.0.6",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randombytes": "^2.1.0",
+                        "underscore": "1.9.1",
+                        "utf8": "3.0.0"
+                    }
+                }
+            }
+        },
         "@cnakazawa/watch": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -1516,23 +2030,23 @@
             }
         },
         "@keep-network/tbtc": {
-            "version": "1.0.2-rc.0",
-            "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.0.2-rc.0.tgz",
-            "integrity": "sha512-a1zcj7gxVb/l4FonZC6ZFXAbQcQXkVmWIMIcq4zDX3P0cxbXczTzRd9QVrw4Y6xBvjjJS5IEVHMLwuu60zrGVQ==",
+            "version": "1.0.3-rc.0",
+            "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.0.3-rc.0.tgz",
+            "integrity": "sha512-XgDbM6MgGCnotY59s0eNL8sxt2L6zpxbrfd1ZRrRdmHZwsl0vtLy4r0qtl2kJ4V2QhnKI6O239kZmn8z4HP7FA==",
             "requires": {
                 "@keep-network/keep-ecdsa": ">1.1.2-rc <1.1.2",
-                "@summa-tx/bitcoin-spv-sol": "^3.0.0",
-                "@summa-tx/relay-sol": "^2.0.1",
+                "@summa-tx/bitcoin-spv-sol": "^3.1.0",
+                "@summa-tx/relay-sol": "^2.0.2",
                 "openzeppelin-solidity": "2.3.0"
             }
         },
         "@keep-network/tbtc.js": {
-            "version": "1.0.2-rc.0",
-            "resolved": "https://registry.npmjs.org/@keep-network/tbtc.js/-/tbtc.js-1.0.2-rc.0.tgz",
-            "integrity": "sha512-KA7z9tVko9wHkSFsB7lLVszykm82a9O6MBo4j1x8xhDqOOia+o4LhWrib5owASsUkN/1pjYSgolZBjvRvFOfVA==",
+            "version": "0.16.0-rc.0",
+            "resolved": "https://registry.npmjs.org/@keep-network/tbtc.js/-/tbtc.js-0.16.0-rc.0.tgz",
+            "integrity": "sha512-CU/7wN4UZtaAWsMzOx2QsqV+zdFvhg7ppKdcQg7FLi/eZpV3U2+KSznq1MDF51+UxOy+J/SXQxO+73h/ySwXDA==",
             "requires": {
                 "@keep-network/keep-ecdsa": ">1.1.2-rc <1.1.2",
-                "@keep-network/tbtc": ">1.0.2-rc <1.0.2",
+                "@keep-network/tbtc": ">1.0.3-rc <1.0.3",
                 "bcoin": "git+https://github.com/bcoin-org/bcoin.git#8851582",
                 "bcrypto": "^4.1.0",
                 "bufio": "^1.0.7",
@@ -1566,6 +2080,67 @@
                     }
                 }
             }
+        },
+        "@ledgerhq/devices": {
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.19.0.tgz",
+            "integrity": "sha512-b8isGErLpGOYnAIswav54j7EWmynTQOvnXriny3eqgzpLt8HOJ9g+C6+67RDzFidwz+5RZW+Qn+ZWAQ3Xo5e/g==",
+            "requires": {
+                "@ledgerhq/errors": "^5.19.0",
+                "@ledgerhq/logs": "^5.19.0",
+                "rxjs": "^6.6.0"
+            },
+            "dependencies": {
+                "rxjs": {
+                    "version": "6.6.0",
+                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.0.tgz",
+                    "integrity": "sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==",
+                    "requires": {
+                        "tslib": "^1.9.0"
+                    }
+                }
+            }
+        },
+        "@ledgerhq/errors": {
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.19.0.tgz",
+            "integrity": "sha512-UrRS1xZ/UidIrGyM+h/T/h57DpiFgfqMtlu5VBic1LbekNUojBPx0cMb099p07uyEwKggfawzbdLmxv4j9Ct+g=="
+        },
+        "@ledgerhq/hw-app-eth": {
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-5.19.0.tgz",
+            "integrity": "sha512-iq5ErfG9uV3CkCIvlzehHfghvED/geXraE5LQon4bsdvrmL5V9BI7GkSAF/ZkTbvB9+PCiBthiSIdcqvJhABQA==",
+            "requires": {
+                "@ledgerhq/errors": "^5.19.0",
+                "@ledgerhq/hw-transport": "^5.19.0",
+                "bignumber.js": "^9.0.0",
+                "rlp": "^2.2.5"
+            },
+            "dependencies": {
+                "rlp": {
+                    "version": "2.2.5",
+                    "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.5.tgz",
+                    "integrity": "sha512-y1QxTQOp0OZnjn19FxBmped4p+BSKPHwGndaqrESseyd2xXZtcgR3yuTIosh8CaMaOii9SKIYerBXnV/CpJ3qw==",
+                    "requires": {
+                        "bn.js": "^4.11.1"
+                    }
+                }
+            }
+        },
+        "@ledgerhq/hw-transport": {
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.19.0.tgz",
+            "integrity": "sha512-MpIut+ZX88PPKmiqX+Df1lch930/Io0SqvjNPtXbYSg1SVZjxW8t85OuAwzukkaXr3tfUTb6IFlSHKC+QYCSBA==",
+            "requires": {
+                "@ledgerhq/devices": "^5.19.0",
+                "@ledgerhq/errors": "^5.19.0",
+                "events": "^3.1.0"
+            }
+        },
+        "@ledgerhq/logs": {
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.19.0.tgz",
+            "integrity": "sha512-gShImyBi0UQUc3Oo3nNwhGDovo1SNRKZYkhA2OKgeUe7PPiKBGuRqfD+cCvvgxcaoTbWlRYeOWbtShnRLRT8HA=="
         },
         "@mrmlnc/readdir-enhanced": {
             "version": "2.2.1",
@@ -1614,9 +2189,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.12.47",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
-                    "integrity": "sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A=="
+                    "version": "12.12.48",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.48.tgz",
+                    "integrity": "sha512-m3Nmo/YaDUfYzdCQlxjF5pIy7TNyDTAJhIa//xtHcF0dlgYIBKULKnmloCPtByDxtZXrWV8Pge1AKT6/lRvVWg=="
                 },
                 "ansi-styles": {
                     "version": "3.2.1",
@@ -1831,26 +2406,65 @@
             "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.6.2.tgz",
             "integrity": "sha512-kUVUvrqttndeprLoXjI5arWHeiP3uh4XODAKbG+ZaWHCVQeelxCbnXBeWxZ2BPHdXgH0xR9dU1b916JhDhbgAA=="
         },
+        "@stablelib/binary": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-0.7.2.tgz",
+            "integrity": "sha1-GzOSFwyKh0HIuPhD6ilN5xrrLPc=",
+            "requires": {
+                "@stablelib/int": "^0.5.0"
+            }
+        },
+        "@stablelib/blake2s": {
+            "version": "0.10.4",
+            "resolved": "https://registry.npmjs.org/@stablelib/blake2s/-/blake2s-0.10.4.tgz",
+            "integrity": "sha512-IasdklC7YfXXLmVbnsxqmd66+Ki+Ysbp0BtcrNxAtrGx/HRGjkUZbSTbEa7HxFhBWIstJRcE5ExgY+RCqAiULQ==",
+            "requires": {
+                "@stablelib/binary": "^0.7.2",
+                "@stablelib/hash": "^0.5.0",
+                "@stablelib/wipe": "^0.5.0"
+            }
+        },
+        "@stablelib/blake2xs": {
+            "version": "0.10.4",
+            "resolved": "https://registry.npmjs.org/@stablelib/blake2xs/-/blake2xs-0.10.4.tgz",
+            "integrity": "sha512-1N0S4cruso/StV9TmoujPGj3RU0Cy42wlZneBWLWby7m2ssnY57l/CsYQSm03TshOoYss4hqc5kwSy5pmWAdUA==",
+            "requires": {
+                "@stablelib/blake2s": "^0.10.4",
+                "@stablelib/hash": "^0.5.0",
+                "@stablelib/wipe": "^0.5.0"
+            }
+        },
+        "@stablelib/hash": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-0.5.0.tgz",
+            "integrity": "sha1-if6QQKPUODsZIcfYpglIvDCEYGg="
+        },
+        "@stablelib/int": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-0.5.0.tgz",
+            "integrity": "sha1-zKkiWVHVXS3khlZ1V4R4hjNmDCs="
+        },
+        "@stablelib/wipe": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-0.5.0.tgz",
+            "integrity": "sha1-poLV+USOlQ4JnlN+b3L8lgJ10VE="
+        },
         "@summa-tx/bitcoin-spv-sol": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@summa-tx/bitcoin-spv-sol/-/bitcoin-spv-sol-3.1.0.tgz",
             "integrity": "sha512-YIwxTNCTIsL+qgzcMhzQk9f0A7yQ6dimlLj4i3gGhWrnqBIg3ljBxJ/aj9JRQyIdNDoCPmqS2s8ZZIdyM+vaGQ=="
         },
         "@summa-tx/relay-sol": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@summa-tx/relay-sol/-/relay-sol-2.0.1.tgz",
-            "integrity": "sha512-AmE9v6sRW/PwoJiZ2C2HVfrPVVOkf9HNuEOqo4ewfZzbJsKp4AFm/dZ6+IcXWBiY28gdhS70OFSvqb85KKWkNg==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@summa-tx/relay-sol/-/relay-sol-2.0.2.tgz",
+            "integrity": "sha512-r5pNimQwpHklxrP+LAvNrhz4jdngVw8ret/98Ls1rLhleVCKKOFHpsRnh9zUzIDqlhIOOQwTZNe5wn7Ex63HNA==",
             "requires": {
-                "@summa-tx/bitcoin-spv-sol": "^2.2.0",
+                "@celo/contractkit": "^0.3.3",
+                "@summa-tx/bitcoin-spv-sol": "^3.1.0",
                 "bn.js": "^5.1.1",
                 "dotenv": "^8.2.0"
             },
             "dependencies": {
-                "@summa-tx/bitcoin-spv-sol": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/@summa-tx/bitcoin-spv-sol/-/bitcoin-spv-sol-2.2.0.tgz",
-                    "integrity": "sha512-HSfxfNldNS4pvZUjLLYqw/wgVrxmIzp67WoRVTxY5SEV7TbOBcn8aYlPCnyLSUX6TeHjMVjAv3inDoIq0zwfCQ=="
-                },
                 "bn.js": {
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
@@ -2049,6 +2663,14 @@
                 "@babel/types": "^7.3.0"
             }
         },
+        "@types/bignumber.js": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-5.0.0.tgz",
+            "integrity": "sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==",
+            "requires": {
+                "bignumber.js": "*"
+            }
+        },
         "@types/bn.js": {
             "version": "4.11.6",
             "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
@@ -2064,6 +2686,11 @@
             "requires": {
                 "@types/node": "*"
             }
+        },
+        "@types/debug": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+            "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
         },
         "@types/istanbul-lib-coverage": {
             "version": "2.0.1",
@@ -2156,6 +2783,10 @@
                     "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
                 }
             }
+        },
+        "@umpirsky/country-list": {
+            "version": "git://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
+            "from": "git://github.com/umpirsky/country-list.git#05fda51"
         },
         "@web3-js/scrypt-shim": {
             "version": "0.1.0",
@@ -2558,6 +3189,11 @@
                 "readable-stream": "^2.0.6"
             }
         },
+        "arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+        },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2696,6 +3332,11 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "assertion-error": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
         },
         "assign-symbols": {
             "version": "1.0.0",
@@ -3431,10 +4072,20 @@
                 "bsert": "~0.0.10"
             }
         },
+        "big-integer": {
+            "version": "1.6.48",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+            "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+        },
         "big.js": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
             "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+        },
+        "bigi": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
+            "integrity": "sha1-nGZalfiLiwj8Bc/XMfVhhZ1yWCU="
         },
         "bignumber.js": {
             "version": "9.0.0",
@@ -3461,6 +4112,27 @@
             "requires": {
                 "bs32": "~0.1.5",
                 "bsert": "~0.0.10"
+            }
+        },
+        "bip32": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.5.tgz",
+            "integrity": "sha512-zVY4VvJV+b2fS0/dcap/5XLlpqtgwyN8oRkuGgAS1uLOeEp0Yo6Tw2yUTozTtlrMJO3G8n4g/KX/XGFHW6Pq3g==",
+            "requires": {
+                "@types/node": "10.12.18",
+                "bs58check": "^2.1.1",
+                "create-hash": "^1.2.0",
+                "create-hmac": "^1.1.7",
+                "tiny-secp256k1": "^1.1.3",
+                "typeforce": "^1.11.5",
+                "wif": "^2.0.6"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "10.12.18",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+                    "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+                }
             }
         },
         "bip39": {
@@ -3514,6 +4186,26 @@
             "integrity": "sha512-34+xZ2u4ys/aUzWCU9m6Eee4nVuN1ywdxbi8b3Z2WULU6qvnfeHvCWEdGzlVfRbbhimG2xxJX6R77GD2cuVO6w==",
             "requires": {
                 "bsert": "~0.0.10"
+            }
+        },
+        "bls12377js": {
+            "version": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
+            "from": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
+            "requires": {
+                "@stablelib/blake2xs": "0.10.4",
+                "@types/node": "^12.11.7",
+                "big-integer": "^1.6.44",
+                "chai": "^4.2.0",
+                "mocha": "^6.2.2",
+                "ts-node": "^8.4.1",
+                "typescript": "^3.6.4"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "12.12.48",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.48.tgz",
+                    "integrity": "sha512-m3Nmo/YaDUfYzdCQlxjF5pIy7TNyDTAJhIa//xtHcF0dlgYIBKULKnmloCPtByDxtZXrWV8Pge1AKT6/lRvVWg=="
+                }
             }
         },
         "blst": {
@@ -3664,6 +4356,11 @@
                     "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
                 }
             }
+        },
+        "browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
         },
         "browserify-aes": {
             "version": "1.2.0",
@@ -3877,6 +4574,11 @@
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/buffer-map/-/buffer-map-0.0.7.tgz",
             "integrity": "sha512-95try3p/vMRkIAAnJDaGkFhGpT/65NoeW6XelEPjAomWYR58RQtW4khn0SwKj34kZoE7uxL7w2koZSwbnszvQQ=="
+        },
+        "buffer-reverse": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
+            "integrity": "sha1-SSg8jvpvkBvAH6MwTQYCeXGuL2A="
         },
         "buffer-to-arraybuffer": {
             "version": "0.0.5",
@@ -4120,6 +4822,19 @@
                 "nofilter": "^1.0.3"
             }
         },
+        "chai": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+            "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+            "requires": {
+                "assertion-error": "^1.1.0",
+                "check-error": "^1.0.2",
+                "deep-eql": "^3.0.1",
+                "get-func-name": "^2.0.0",
+                "pathval": "^1.1.0",
+                "type-detect": "^4.0.5"
+            }
+        },
         "chalk": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -4136,6 +4851,11 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
             "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+        },
+        "check-error": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+            "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
         },
         "checkpoint-store": {
             "version": "1.1.0",
@@ -5151,6 +5871,15 @@
                 }
             }
         },
+        "country-data": {
+            "version": "0.0.31",
+            "resolved": "https://registry.npmjs.org/country-data/-/country-data-0.0.31.tgz",
+            "integrity": "sha1-gJZrjh0Uf6bWpYnTKTP4eTd0lW0=",
+            "requires": {
+                "currency-symbol-map": "~2",
+                "underscore": ">1.4.4"
+            }
+        },
         "create-ecdh": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
@@ -5183,6 +5912,22 @@
                 "ripemd160": "^2.0.0",
                 "safe-buffer": "^5.0.1",
                 "sha.js": "^2.4.8"
+            }
+        },
+        "cross-fetch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
+            "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
+            "requires": {
+                "node-fetch": "2.6.0",
+                "whatwg-fetch": "3.0.0"
+            },
+            "dependencies": {
+                "node-fetch": {
+                    "version": "2.6.0",
+                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+                    "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+                }
             }
         },
         "cross-spawn": {
@@ -5451,6 +6196,11 @@
                 "cssom": "0.3.x"
             }
         },
+        "currency-symbol-map": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/currency-symbol-map/-/currency-symbol-map-2.2.0.tgz",
+            "integrity": "sha1-KzwYcv8aws5ZXYJz5Y4f/wJyrqI="
+        },
         "currently-unhandled": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -5613,6 +6363,14 @@
                         "pinkie-promise": "^2.0.0"
                     }
                 }
+            }
+        },
+        "deep-eql": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+            "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+            "requires": {
+                "type-detect": "^4.0.0"
             }
         },
         "deep-equal": {
@@ -5830,6 +6588,11 @@
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
+        },
+        "diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
         },
         "diff-sequences": {
             "version": "24.9.0",
@@ -6873,17 +7636,17 @@
             }
         },
         "ethereumjs-wallet": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.3.tgz",
-            "integrity": "sha512-qiXPiZOsStem+Dj/CQHbn5qex+FVkuPmGH7SvSnA9F3tdRDt8dLMyvIj3+U05QzVZNPYh4HXEdnzoYI4dZkr9w==",
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.4.tgz",
+            "integrity": "sha512-xAYLWVH/MA9Ds1+BiDTfdRrCBQIz7r70EJSjuBnvw/x40qJ1jBoBBAp8/l+I9VPGAsUXvHTfcnp2OZ9LbcTs/g==",
             "requires": {
                 "aes-js": "^3.1.1",
                 "bs58check": "^2.1.2",
                 "ethereumjs-util": "^6.0.0",
-                "hdkey": "^1.1.0",
+                "hdkey": "^1.1.1",
                 "randombytes": "^2.0.6",
                 "safe-buffer": "^5.1.2",
-                "scrypt.js": "^0.3.0",
+                "scryptsy": "^1.2.1",
                 "utf8": "^3.0.0",
                 "uuid": "^3.3.2"
             },
@@ -6892,6 +7655,14 @@
                     "version": "3.1.2",
                     "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
                     "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
+                },
+                "scryptsy": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
+                    "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
+                    "requires": {
+                        "pbkdf2": "^3.0.3"
+                    }
                 }
             }
         },
@@ -7470,6 +8241,21 @@
                 "pinkie-promise": "^2.0.0"
             }
         },
+        "flat": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+            "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+            "requires": {
+                "is-buffer": "~2.0.3"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+                    "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+                }
+            }
+        },
         "flat-cache": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -7616,6 +8402,11 @@
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
             "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
         },
+        "fp-ts": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.1.1.tgz",
+            "integrity": "sha512-YcWhMdDCFCja0MmaDroTgNu+NWWrrnUEn92nvDgrtVy9Z71YFnhNVIghoHPt8gs82ijoMzFGeWKvArbyICiJgw=="
+        },
         "fragment-cache": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -7716,6 +8507,11 @@
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
         },
+        "futoin-hkdf": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.3.2.tgz",
+            "integrity": "sha512-3EVi3ETTyJg5PSXlxLCaUVVn0pSbDf62L3Gwxne7Uq+d8adOSNWQAad4gg7WToHkcgnCJb3Wlb1P8r4Evj4GPw=="
+        },
         "gauge": {
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -7748,6 +8544,11 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
             "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+        },
+        "get-func-name": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+            "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
         },
         "get-own-enumerable-property-symbols": {
             "version": "3.0.2",
@@ -7897,6 +8698,11 @@
                 "minimatch": "~3.0.2"
             }
         },
+        "google-libphonenumber": {
+            "version": "3.2.10",
+            "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.10.tgz",
+            "integrity": "sha512-TsckE9O8QgqaIeaOXPjcJa4/kX3BzFdO1oCbMfmUpRZckml4xJhjJVxaT9Mdt/VrZZkT9lX44eHAEWfJK1tHtw=="
+        },
         "got": {
             "version": "9.6.0",
             "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -7924,6 +8730,11 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
             "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+        },
+        "growl": {
+            "version": "1.10.5",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
         },
         "growly": {
             "version": "1.3.0",
@@ -8590,6 +9401,11 @@
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
             "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
         },
+        "io-ts": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.0.1.tgz",
+            "integrity": "sha512-RezD+WcCfW4VkMkEcQWL/Nmy/nqsWTvTYg7oUmTGzglvSSV2P9h2z1PVeREPFf0GWNzruYleAt1XCMQZSg1xxQ=="
+        },
         "ip": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -8716,6 +9532,11 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
             "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "is-function": {
             "version": "1.0.1",
@@ -11017,6 +11838,28 @@
                 "safe-buffer": "^5.2.0"
             }
         },
+        "keccak256": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.0.tgz",
+            "integrity": "sha512-8qv2vJdQk+Aa2tFXo8zYodm+6DgXqUOqvNJhj1p1V2pxQJT1oNKxNF+zWfhtKXNLZdLvyxjB/dvd9GwcvTHSQQ==",
+            "requires": {
+                "bn.js": "^4.11.8",
+                "keccak": "^1.4.0"
+            },
+            "dependencies": {
+                "keccak": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+                    "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+                    "requires": {
+                        "bindings": "^1.2.1",
+                        "inherits": "^2.0.3",
+                        "nan": "^2.2.1",
+                        "safe-buffer": "^5.1.0"
+                    }
+                }
+            }
+        },
         "keyv": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -11338,6 +12181,42 @@
             "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
             "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
         },
+        "log-symbols": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+            "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+            "requires": {
+                "chalk": "^2.0.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
         "loglevel": {
             "version": "1.6.7",
             "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
@@ -11405,6 +12284,11 @@
                     "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
                 }
             }
+        },
+        "make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
         },
         "makeerror": {
             "version": "1.0.11",
@@ -11820,6 +12704,230 @@
                 "mkdirp": "*"
             }
         },
+        "mocha": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.3.tgz",
+            "integrity": "sha512-0R/3FvjIGH3eEuG17ccFPk117XL2rWxatr81a57D+r/x2uTYZRbdZ4oVidEUMh2W2TJDa7MdAb12Lm2/qrKajg==",
+            "requires": {
+                "ansi-colors": "3.2.3",
+                "browser-stdout": "1.3.1",
+                "debug": "3.2.6",
+                "diff": "3.5.0",
+                "escape-string-regexp": "1.0.5",
+                "find-up": "3.0.0",
+                "glob": "7.1.3",
+                "growl": "1.10.5",
+                "he": "1.2.0",
+                "js-yaml": "3.13.1",
+                "log-symbols": "2.2.0",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.4",
+                "ms": "2.1.1",
+                "node-environment-flags": "1.0.5",
+                "object.assign": "4.1.0",
+                "strip-json-comments": "2.0.1",
+                "supports-color": "6.0.0",
+                "which": "1.3.1",
+                "wide-align": "1.1.3",
+                "yargs": "13.3.2",
+                "yargs-parser": "13.1.2",
+                "yargs-unparser": "1.6.0"
+            },
+            "dependencies": {
+                "ansi-colors": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+                    "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw=="
+                },
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+                },
+                "cliui": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+                    "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+                    "requires": {
+                        "string-width": "^3.1.0",
+                        "strip-ansi": "^5.2.0",
+                        "wrap-ansi": "^5.1.0"
+                    }
+                },
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "get-caller-file": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+                    "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+                },
+                "glob": {
+                    "version": "7.1.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.4",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+                    "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+                    "requires": {
+                        "minimist": "^1.2.5"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+                },
+                "p-limit": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+                },
+                "require-main-filename": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+                    "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+                    "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+                },
+                "wrap-ansi": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+                    "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "string-width": "^3.0.0",
+                        "strip-ansi": "^5.0.0"
+                    }
+                },
+                "y18n": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+                    "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+                },
+                "yargs": {
+                    "version": "13.3.2",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+                    "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+                    "requires": {
+                        "cliui": "^5.0.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^3.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^13.1.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "13.1.2",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+                    "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
         "mock-fs": {
             "version": "4.11.0",
             "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.11.0.tgz",
@@ -11952,6 +13060,22 @@
             "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
             "requires": {
                 "lower-case": "^1.1.1"
+            }
+        },
+        "node-environment-flags": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+            "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+            "requires": {
+                "object.getownpropertydescriptors": "^2.0.3",
+                "semver": "^5.7.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                }
             }
         },
         "node-fetch": {
@@ -12348,6 +13472,11 @@
                     "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
                 }
             }
+        },
+        "numeral": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+            "integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY="
         },
         "nwsapi": {
             "version": "2.2.0",
@@ -12792,6 +13921,11 @@
                 "pify": "^2.0.0",
                 "pinkie-promise": "^2.0.0"
             }
+        },
+        "pathval": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+            "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
         },
         "pbkdf2": {
             "version": "3.0.17",
@@ -15277,15 +16411,6 @@
                 "ajv-keywords": "^3.1.0"
             }
         },
-        "scrypt": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
-            "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
-            "optional": true,
-            "requires": {
-                "nan": "^2.0.8"
-            }
-        },
         "scrypt-js": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
@@ -15303,25 +16428,6 @@
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                }
-            }
-        },
-        "scrypt.js": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.3.0.tgz",
-            "integrity": "sha512-42LTc1nyFsyv/o0gcHtDztrn+aqpkaCNt5Qh7ATBZfhEZU7IC/0oT/qbBH+uRNoAPvs2fwiOId68FDEoSRA8/A==",
-            "requires": {
-                "scrypt": "^6.0.2",
-                "scryptsy": "^1.2.1"
-            },
-            "dependencies": {
-                "scryptsy": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
-                    "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
-                    "requires": {
-                        "pbkdf2": "^3.0.3"
-                    }
                 }
             }
         },
@@ -17029,6 +18135,18 @@
             "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
             "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
         },
+        "tiny-secp256k1": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz",
+            "integrity": "sha512-duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==",
+            "requires": {
+                "bindings": "^1.3.0",
+                "bn.js": "^4.11.8",
+                "create-hmac": "^1.1.7",
+                "elliptic": "^6.4.0",
+                "nan": "^2.13.2"
+            }
+        },
         "tiny-warning": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -17191,6 +18309,34 @@
                 }
             }
         },
+        "ts-node": {
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
+            "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+            "requires": {
+                "arg": "^4.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "source-map-support": "^0.5.17",
+                "yn": "3.1.1"
+            },
+            "dependencies": {
+                "diff": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+                    "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+                },
+                "source-map-support": {
+                    "version": "0.5.19",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+                    "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "source-map": "^0.6.0"
+                    }
+                }
+            }
+        },
         "ts-pnp": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.2.tgz",
@@ -17245,6 +18391,11 @@
                 "prelude-ls": "~1.1.2"
             }
         },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+        },
         "type-is": {
             "version": "1.6.18",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -17266,6 +18417,16 @@
             "requires": {
                 "is-typedarray": "^1.0.0"
             }
+        },
+        "typeforce": {
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+            "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
+        },
+        "typescript": {
+            "version": "3.9.6",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+            "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw=="
         },
         "typescript-compare": {
             "version": "0.0.2",
@@ -18072,9 +19233,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.12.47",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
-                    "integrity": "sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A=="
+                    "version": "12.12.48",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.48.tgz",
+                    "integrity": "sha512-m3Nmo/YaDUfYzdCQlxjF5pIy7TNyDTAJhIa//xtHcF0dlgYIBKULKnmloCPtByDxtZXrWV8Pge1AKT6/lRvVWg=="
                 },
                 "eth-lib": {
                     "version": "0.2.7",
@@ -18553,9 +19714,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.12.47",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
-                    "integrity": "sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A=="
+                    "version": "12.12.48",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.48.tgz",
+                    "integrity": "sha512-m3Nmo/YaDUfYzdCQlxjF5pIy7TNyDTAJhIa//xtHcF0dlgYIBKULKnmloCPtByDxtZXrWV8Pge1AKT6/lRvVWg=="
                 },
                 "eth-lib": {
                     "version": "0.2.7",
@@ -19216,6 +20377,14 @@
                 "string-width": "^1.0.2 || 2"
             }
         },
+        "wif": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+            "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+            "requires": {
+                "bs58check": "<3.0.0"
+            }
+        },
         "window-size": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
@@ -19594,6 +20763,163 @@
                 "lodash.assign": "^4.0.6"
             }
         },
+        "yargs-unparser": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+            "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+            "requires": {
+                "flat": "^4.1.0",
+                "lodash": "^4.17.15",
+                "yargs": "^13.3.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+                },
+                "cliui": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+                    "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+                    "requires": {
+                        "string-width": "^3.1.0",
+                        "strip-ansi": "^5.2.0",
+                        "wrap-ansi": "^5.1.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "get-caller-file": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+                    "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+                },
+                "require-main-filename": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+                    "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+                },
+                "wrap-ansi": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+                    "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "string-width": "^3.0.0",
+                        "strip-ansi": "^5.0.0"
+                    }
+                },
+                "y18n": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+                    "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+                },
+                "yargs": {
+                    "version": "13.3.2",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+                    "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+                    "requires": {
+                        "cliui": "^5.0.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^3.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^13.1.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "13.1.2",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+                    "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
         "yauzl": {
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
@@ -19602,6 +20928,11 @@
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
             }
+        },
+        "yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2030,9 +2030,9 @@
             }
         },
         "@keep-network/tbtc": {
-            "version": "1.0.3-rc.0",
-            "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.0.3-rc.0.tgz",
-            "integrity": "sha512-XgDbM6MgGCnotY59s0eNL8sxt2L6zpxbrfd1ZRrRdmHZwsl0vtLy4r0qtl2kJ4V2QhnKI6O239kZmn8z4HP7FA==",
+            "version": "1.0.3-rc.1",
+            "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.0.3-rc.1.tgz",
+            "integrity": "sha512-2Uas+EZGcptX9KFf7OOGNsTNwnpsomBQbmB01xUJvKadQ636nWgYK6xajA9i8ouieNZ8jL6JxbIxexpmv0atmA==",
             "requires": {
                 "@keep-network/keep-ecdsa": ">1.1.2-rc <1.1.2",
                 "@summa-tx/bitcoin-spv-sol": "^3.1.0",
@@ -2041,9 +2041,9 @@
             }
         },
         "@keep-network/tbtc.js": {
-            "version": "0.16.0-rc.0",
-            "resolved": "https://registry.npmjs.org/@keep-network/tbtc.js/-/tbtc.js-0.16.0-rc.0.tgz",
-            "integrity": "sha512-CU/7wN4UZtaAWsMzOx2QsqV+zdFvhg7ppKdcQg7FLi/eZpV3U2+KSznq1MDF51+UxOy+J/SXQxO+73h/ySwXDA==",
+            "version": "0.16.0-rc.1",
+            "resolved": "https://registry.npmjs.org/@keep-network/tbtc.js/-/tbtc.js-0.16.0-rc.1.tgz",
+            "integrity": "sha512-PJRWLYzx1NszGXMn8/4rtBR4BCPXG+4yYd9nzEghZw5ZdRWXEqNnG3ZauglelTWiRjQSu7P18BTYNWACxdnwsQ==",
             "requires": {
                 "@keep-network/keep-ecdsa": ">1.1.2-rc <1.1.2",
                 "@keep-network/tbtc": ">1.0.3-rc <1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "tbtc-dapp",
-    "version": "0.16.4-rc",
+    "version": "0.16.5-rc",
     "dependencies": {
-        "@keep-network/tbtc.js": ">0.15.0-rc <0.15.0",
+        "@keep-network/tbtc.js": ">0.16.0-rc <0.16.0",
         "@web3-react/core": "^6.0.7",
         "@web3-react/injected-connector": "^6.0.7",
         "bignumber.js": "^9.0.0",


### PR DESCRIPTION
### Intro

Picking up the new tbtc.js version 0.16.0-rc.   This should allow us to have more reliable tBTC minting on testnet via reducing the number of wait confirmations required to mint.

### Related

https://github.com/keep-network/tbtc/pull/697
https://github.com/keep-network/tbtc.js/pull/50