### PR TITLE
Created a github issue template to get better bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels: bug
 
 
 ### Description:
-A clear and concise description of what the bug is and where it appeared e.g. did it appear in the browser or in wallet (e.g. metamask). If the bug was in the broswer, what was url at that point.
+A clear and concise description of what the bug is and where it appeared e.g. did it appear in the browser or in wallet (e.g. MetaMask). If the bug was in the browser, what was url at that point.
 
 ### Steps to reproduce the behavior:
 1. Go to '...'

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,10 @@
+---
+name: Bug Report
+about: Use this template for reporting bugs.
+labels: bug
+---
+
+
 ### Description:
 A clear and concise description of what the bug is and where it appeared e.g. did it appear in the browser or in wallet (e.g. metamask). If the bug was in the broswer, what was url at that point.
 
@@ -9,7 +16,6 @@ A clear and concise description of what the bug is and where it appeared e.g. di
 
 ### Expected behavior:
 A clear and concise description of what you expected to happen.
-
 
 ### Environment details:
 OS: Windows 10 Pro, Version 1909, build 18363.900, 64 bit OS  

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+### Description:
+A clear and concise description of what the bug is and where it appeared e.g. did it appear in the browser or in wallet (e.g. metamask). If the bug was in the broswer, what was url at that point.
+
+### Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### Expected behavior:
+A clear and concise description of what you expected to happen.
+
+
+### Environment details:
+OS: Windows 10 Pro, Version 1909, build 18363.900, 64 bit OS  
+Web Browser: Google Chrome, Version 83.0.4103.116 (Official Build) (64-bit)  
+Wallet: Metamask (Chrome extension), Version 7.7.9
+
+### Additional context:
+Add any other context about the problem here.
+
+### Screenshots
+If applicable, add screenshots to help explain your problem and any console log files.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Use this template for reporting bugs.
+about: Use this template for reporting bugs
 labels: bug
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_idea.md
+++ b/.github/ISSUE_TEMPLATE/feature_idea.md
@@ -1,0 +1,5 @@
+---
+name: Feature Idea
+about: Suggest an idea or feature to help improve tBTC dApp
+labels: enhancement
+---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,0 @@
----
-name: Feature Request
-about: Submit a feature request.
-labels: enhancement
----

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,5 @@
+---
+name: Feature Request
+about: Submit a feature request.
+labels: enhancement
+---

--- a/.github/ISSUE_TEMPLATE/other_issue.md
+++ b/.github/ISSUE_TEMPLATE/other_issue.md
@@ -1,0 +1,5 @@
+---
+name: General Issue
+about: Use this template for geenral issues.
+labels: bug
+---

--- a/.github/ISSUE_TEMPLATE/other_issue.md
+++ b/.github/ISSUE_TEMPLATE/other_issue.md
@@ -1,5 +1,5 @@
 ---
 name: General Issue
-about: Use this template for geenral issues.
+about: Use this template for general issues
 labels: bug
 ---


### PR DESCRIPTION
I've created a github issue template to help the KEEP team and developers receive better documented bug reports. I hope this will help the KEEP community submit higher quality issues on github, and consequently help to resolve issues quicker.

I used the directory structure which allows creation of multiple templates (so in future we could have more templates e.g. one for feature requests). In this case, github uses the `template` query parameter to specify a template to fill the issue body.
Please see [github's issue template docs](https://docs.github.com/en/github/building-a-strong-community/manually-creating-a-single-issue-template-for-your-repository) for more info.