### PR TITLE
Removed 'bug' label from general issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/other_issue.md
+++ b/.github/ISSUE_TEMPLATE/other_issue.md
@@ -1,5 +1,5 @@
 ---
 name: General Issue
 about: Use this template for general issues
-labels: bug
+labels:
 ---


### PR DESCRIPTION
I overlooked this when I made the template but I don't think it makes sense to include the bug label for this 'general issue' template since there is already a specific 'bug report' template (which includes the bug label). Would that make issues better organized or am I being too meticulous?