### PR TITLE
add reminder to connect wallet in deposit flow

### DIFF
--- a/src/components/deposit/Start.js
+++ b/src/components/deposit/Start.js
@@ -49,7 +49,12 @@ const Start = ({
         Step 1/5
       </div>
       <div className="title">
-        { error ? 'Error getting available lot sizes' : 'Select Lot Size' }
+        { typeof account === 'undefined'
+          ? 'Connect Wallet to Continue'
+          : (error
+            ? 'Error getting available lot sizes'
+            : 'Select Lot Size')
+        }
       </div>
       <hr />
       <Description error={error}>

--- a/src/components/redemption/Start.js
+++ b/src/components/redemption/Start.js
@@ -93,7 +93,7 @@ class Start extends Component {
             Step 1/6
           </div>
           <div className="title">
-            Redeem bond
+            Redeem Bond
           </div>
           <hr />
           <div className="description">

--- a/src/wrappers/loadable.js
+++ b/src/wrappers/loadable.js
@@ -31,7 +31,7 @@ function LoadableBase({ children, restoreDepositState, restoreRedemptionState, r
     if(!depositStateRestored) {
         return <div className="pay">
             <div className="page-top">
-                <p>Loading...</p>
+                <p>Connect Wallet to Continue</p>
             </div>
             <div className="page-body">
             </div>


### PR DESCRIPTION
## Issue

It's not obvious how to progress when landing on the deposit flow because the 'connect wallet' button is fairly small and the title text doesn't indicate that connecting a wallet is necessary.

## Change

Title now reads "Connect Wallet to Continue"

![image](https://user-images.githubusercontent.com/2591290/89042862-7aad7100-d2fc-11ea-9635-a1b3ed5b819f.png)

and changes to "Select Lot Size" once a wallet is connected

![image](https://user-images.githubusercontent.com/2591290/89042896-8ac55080-d2fc-11ea-8a0b-b7147ec6326e.png)
