### PR TITLE
magically hex TDT ID if given in decimal

### DIFF
--- a/src/components/redemption/Start.js
+++ b/src/components/redemption/Start.js
@@ -37,12 +37,17 @@ class Start extends Component {
 
   handleDepositAddressChange = (evt) => {
     const address = evt.target.value
+    const addressHexed = web3.utils.toHex(address)
 
-    const isValid = web3.utils.isAddress(address)
-    const hasError = ! isValid
+    const isValidAddr = web3.utils.isAddress(address)
+    const isValidAddrDecimal = web3.utils.isAddress(addressHexed)
 
+    const isValid = isValidAddr || isValidAddrDecimal
+    const addr = isValidAddrDecimal ? addressHexed : address
+    const hasError = ! isValid && ! isValidAddrDecimal
+    
     this.setState({
-      depositAddress: address,
+      depositAddress: addr,
       depositAddressIsValid: isValid,
       depositAddressHasError: hasError
     })


### PR DESCRIPTION
TDT IDs are given in decimal in many block explorers: https://ropsten.etherscan.io/token/0x20ea5b307ee28eefc15a3e6d945c5e8da5a8add9

If a decimal TDT ID is provided, automatically convert from decimal to a hex address.