### PR TITLE
Update file format of exported logs to txt

### DIFF
--- a/src/components/lib/Footer.js
+++ b/src/components/lib/Footer.js
@@ -82,7 +82,7 @@ class Footer extends Component {
           <a
             className="download-error-button" onClick={this.handleDownloadError}
             href={this.state.errorLogUrl}
-            download={`tbtc-dapp-v${version}-log-${new Date().getTime()}.json`}>
+            download={`tbtc-dapp-v${version}-log-${new Date().getTime()}.txt`}>
               Download Error Log ↓
           </a>
         </div>

--- a/src/css/confirming.scss
+++ b/src/css/confirming.scss
@@ -9,6 +9,8 @@
             a {
                 @extend .button;
                 @extend .button.black;
+                display: inline-block;
+                margin-top: 1em;
             }
         }
     }


### PR DESCRIPTION
Changes the file format from json to txt so it's easier to upload to GitHub. Also threw in a small visual fix for the "Follow along in block explorer" button on the redemption confirming page.