### PR TITLE
Config-tastic: Give TBTC.withConfig a specific Electrum config

### DIFF
--- a/src/config/config.json
+++ b/src/config/config.json
@@ -1,19 +1,24 @@
 {
     "electrum": {
-        "testnet": {
-            "server": "electrumx-server.test.tbtc.network",
-            "port": 50002,
-            "protocol": "ssl"
-        },
-        "testnetPublic": {
-            "server": "testnet1.bauerj.eu",
-            "port": 50002,
-            "protocol": "ssl"
-        },
-        "testnetWS": {
-            "server": "electrumx-server.test.tbtc.network",
-            "port": 8443,
-            "protocol": "wss"
-        }
+      "testnet": {
+        "server": "electrumx-server.test.tbtc.network",
+        "port": 8443,
+        "protocol": "wss"
+      },
+      "testnetTCP": {
+        "server": "electrumx-server.test.tbtc.network",
+        "port": 50002,
+        "protocol": "ssl"
+      },
+      "mainnet": {
+        "server": "electrumx-server.tbtc.network",
+        "port": 8443,
+        "protocol": "wss"
+      },
+      "mainnetTCP": {
+        "server": "electrumx-server.tbtc.network",
+        "port": 50002,
+        "protocol": "ssl"
+      }
     }
 }

--- a/src/wrappers/web3.js
+++ b/src/wrappers/web3.js
@@ -54,7 +54,7 @@ const initializeContracts = async (web3, connector, onTBTCLoaded) => {
     const tbtc = await TBTC.withConfig({
         web3: web3,
         bitcoinNetwork: "testnet",
-        electrum: config.electrum
+        electrum: config.electrum.testnet
     })
 
     TBTCLoadedDeferred.resolve(tbtc)


### PR DESCRIPTION
Previously, TBTC.withConfig took an object and read its testnetWS
property to determine how to configure Electrum. Now, it takes the
Electrum configuration directly, no longer trying to find it in a
specifically-named property.

Draft until keep-network/tbtc.js#69 lands.