### PR TITLE
Flexi-net: Prep for mainnet with a few additional tweaks

### DIFF
--- a/src/components/deposit/Pay.js
+++ b/src/components/deposit/Pay.js
@@ -29,9 +29,19 @@ const PayComponent = ({ btcAddress, btcAmount, signerFee, error }) => {
       </div>
       <div className="page-body">
         <div className="step">Step 2/5</div>
-        <div className="title">Pay: {btcAmount} BTC</div>
+        <div className="title">Pay EXACTLY: {btcAmount} BTC</div>
         <hr />
         <Description error={error}>
+          <div className="warning">
+            <p>To avoid loss of funds, do NOT fund from an exchange.</p>
+
+            <p>
+              Exchanges transfers can result in Bitcoin transactions that cannot
+              be proven on Ethereum. If you have BTC in an exchange, transfer
+              through an intermediary wallet and make a single transaction to
+              the deposit&apos;s funding address.
+            </p>
+          </div>
           <div>
             Scan the QR code or click to copy the address below into your
             wallet.

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -36,6 +36,7 @@ a {
 }
 
 .warning {
+    text-align: left;
     font-family: 'apercu-mono-regular-pro';
     font-size: 0.75rem;
     line-height: 1.5rem;

--- a/src/sagas/lib/index.js
+++ b/src/sagas/lib/index.js
@@ -1,14 +1,15 @@
 import { put } from "redux-saga/effects"
 
 export function* logError(errorActionType, error) {
-  const { message, stack } = error
+  const { message, reason, stack } = error
   yield put({
     type: errorActionType,
     payload: {
-      error: message,
+      error: reason ? `Error: ${reason}` : message,
     },
   })
   console.error({
+    reason,
     message,
     originalStack: stack.split("\n").map((s) => s.trim()),
     error,

--- a/src/wrappers/web3.js
+++ b/src/wrappers/web3.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react"
 import Web3 from "web3"
-import TBTC from "@keep-network/tbtc.js"
+import TBTC, { EthereumHelpers, BitcoinHelpers } from "@keep-network/tbtc.js"
 import { Web3ReactProvider, useWeb3React } from "@web3-react/core"
 import { connect } from "react-redux"
 import { bindActionCreators } from "redux"
@@ -52,11 +52,17 @@ const initializeContracts = async (web3, connector, onTBTCLoaded) => {
 
   Web3LoadedDeferred.resolve(web3)
 
-  const tbtc = await TBTC.withConfig({
-    web3: web3,
-    bitcoinNetwork: "testnet",
-    electrum: config.electrum.testnet,
-  })
+  const tbtc = (await EthereumHelpers.isMainnet(web3))
+    ? await TBTC.withConfig({
+        web3: web3,
+        bitcoinNetwork: BitcoinHelpers.Network.MAINNET,
+        electrum: config.electrum.mainnet,
+      })
+    : await TBTC.withConfig({
+        web3: web3,
+        bitcoinNetwork: BitcoinHelpers.Network.TESTNET,
+        electrum: config.electrum.testnet,
+      })
 
   TBTCLoadedDeferred.resolve(tbtc)
 


### PR DESCRIPTION
Three things here:
- Automatic mainnet config when web3 is set to mainnet.
- Loud warning not to use an exchange for funding.
- Proper surfacing of the revert reason in cases where a transaction fails
  with a clear contract-side reason.

I was going to hold this as a draft until we finalized a rough design
for the exchange warning, but it'll be so easy to make changes in a
follow-up PR that I'll declare this ready for review.

See #297.