### PR TITLE
1-2-3-4: Display the current and required Bitcoin confirmation count

### DIFF
--- a/src/components/deposit/Confirming.js
+++ b/src/components/deposit/Confirming.js
@@ -6,7 +6,12 @@ import Description from "../lib/Description"
 import StatusIndicator from "../svgs/StatusIndicator"
 import { formatSatsToBtc } from "../../utils"
 
-const Confirming = ({ signerFee, error }) => {
+const Confirming = ({
+  signerFee,
+  error,
+  requiredConfirmations,
+  confirmations,
+}) => {
   return (
     <div className="pay pay-confirming">
       <div className="page-top">
@@ -20,8 +25,12 @@ const Confirming = ({ signerFee, error }) => {
         <hr />
         <Description error={error}>
           <div>
-            Waiting for transaction confirmations. We’ll send you a browser
-            notification when your TBTC is ready to be minted.
+            Waiting for {requiredConfirmations} transaction{" "}
+            {`confirmation${requiredConfirmations > 1 ? "s" : ""}`}. We’ll send
+            you a browser notification when your TBTC is ready to be minted.
+            <p>
+              {confirmations} / {requiredConfirmations} blocks confirmed
+            </p>
             <p>
               <i>A watched block never boils.</i>
             </p>
@@ -39,14 +48,23 @@ const Confirming = ({ signerFee, error }) => {
 Confirming.propTypes = {
   signerFee: PropTypes.string,
   error: PropTypes.string,
+  requiredConfirmations: PropTypes.number,
+  confirmations: PropTypes.number,
 }
 
 const mapStateToProps = ({
-  deposit: { signerFeeInSatoshis, btcConfirmingError },
+  deposit: {
+    signerFeeInSatoshis,
+    btcConfirmingError,
+    requiredConfirmations,
+    confirmations,
+  },
 }) => {
   return {
     signerFee: formatSatsToBtc(signerFeeInSatoshis),
     error: btcConfirmingError,
+    requiredConfirmations,
+    confirmations,
   }
 }
 

--- a/src/components/redemption/Confirming.js
+++ b/src/components/redemption/Confirming.js
@@ -49,7 +49,7 @@ Confirming.propTypes = {
 const mapStateToProps = (state) => {
   return {
     txHash: state.redemption.txHash,
-    error: state.redemption.pollForConfirmationsError,
+    error: state.redemption.confirmationError,
     btcNetwork: state.tbtc.btcNetwork,
   }
 }

--- a/src/components/redemption/Confirming.js
+++ b/src/components/redemption/Confirming.js
@@ -5,7 +5,13 @@ import PropTypes from "prop-types"
 import Description from "../lib/Description"
 import StatusIndicator from "../svgs/StatusIndicator"
 
-const Confirming = ({ txHash, btcNetwork, error }) => {
+const Confirming = ({
+  txHash,
+  btcNetwork,
+  error,
+  requiredConfirmations,
+  confirmations,
+}) => {
   const blockExplorerUrl = `https://blockstream.info/${
     btcNetwork === "testnet" ? "testnet/" : ""
   }tx/${txHash}`
@@ -22,7 +28,13 @@ const Confirming = ({ txHash, btcNetwork, error }) => {
         </div>
         <hr />
         <Description error={error}>
-          <p>We&apos;re waiting to confirm your transaction.</p>
+          <p>
+            Waiting for {requiredConfirmations} transaction{" "}
+            {`confirmation${requiredConfirmations > 1 ? "s" : ""}`}.
+          </p>
+          <p>
+            {confirmations} / {requiredConfirmations} blocks confirmed
+          </p>
           {txHash ? (
             <a
               href={blockExplorerUrl}
@@ -44,6 +56,8 @@ Confirming.propTypes = {
   txHash: PropTypes.string,
   btcNetwork: PropTypes.string,
   error: PropTypes.string,
+  requiredConfirmations: PropTypes.number,
+  confirmations: PropTypes.number,
 }
 
 const mapStateToProps = (state) => {
@@ -51,6 +65,8 @@ const mapStateToProps = (state) => {
     txHash: state.redemption.txHash,
     error: state.redemption.confirmationError,
     btcNetwork: state.tbtc.btcNetwork,
+    requiredConfirmations: state.redemption.requiredConfirmations,
+    confirmations: state.redemption.confirmations,
   }
 }
 

--- a/src/css/copy-address-field.scss
+++ b/src/css/copy-address-field.scss
@@ -22,6 +22,7 @@
             border: 1px solid $black;
             border-radius: 6px;
             box-shadow: 6px 6px 0 $black;
+            z-index: 2;
 
             // carets
             &:before,

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -8,6 +8,7 @@ import {
   BTC_TX_SEEN,
   BTC_TX_ERROR,
   BTC_TX_CONFIRMED_WAIT,
+  BTC_TX_REQUIRED_CONFIRMATIONS,
   BTC_TX_CONFIRMED,
   BTC_TX_CONFIRMED_ALL,
   BTC_TX_CONFIRMING_ERROR,
@@ -33,7 +34,8 @@ const initialState = {
   fundingOutputIndex: null,
   btcConfirming: false,
   btcConfirmingTxID: null,
-  confirmations: null,
+  requiredConfirmations: 1,
+  confirmations: 0,
   invoiceStatus: 0,
   isStateReady: false,
   lotSize: null,
@@ -128,6 +130,11 @@ const deposit = (state = initialState, action) => {
       return {
         ...state,
         btcConfirming: true,
+      }
+    case BTC_TX_REQUIRED_CONFIRMATIONS:
+      return {
+        ...state,
+        requiredConfirmations: action.payload.requiredConfirmations,
       }
     case BTC_TX_CONFIRMED:
       return {

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -33,7 +33,7 @@ const initialState = {
   fundingOutputIndex: null,
   btcConfirming: false,
   btcConfirmingTxID: null,
-  confirmations: 0,
+  confirmations: null,
   invoiceStatus: 0,
   isStateReady: false,
   lotSize: null,

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -9,6 +9,7 @@ import {
   BTC_TX_ERROR,
   BTC_TX_CONFIRMED_WAIT,
   BTC_TX_CONFIRMED,
+  BTC_TX_CONFIRMED_ALL,
   BTC_TX_CONFIRMING_ERROR,
   DEPOSIT_AUTO_SUBMIT_PROOF,
   DEPOSIT_PROVE_BTC_TX_BEGIN,
@@ -32,6 +33,7 @@ const initialState = {
   fundingOutputIndex: null,
   btcConfirming: false,
   btcConfirmingTxID: null,
+  confirmations: 0,
   invoiceStatus: 0,
   isStateReady: false,
   lotSize: null,
@@ -128,6 +130,12 @@ const deposit = (state = initialState, action) => {
         btcConfirming: true,
       }
     case BTC_TX_CONFIRMED:
+      return {
+        ...state,
+        btcConfirmingTxID: action.payload.btcConfirmingTxID,
+        confirmations: action.payload.confirmations,
+      }
+    case BTC_TX_CONFIRMED_ALL:
       return {
         ...state,
         btcConfirmingTxID: action.payload.btcConfirmingTxID,

--- a/src/reducers/redemption.js
+++ b/src/reducers/redemption.js
@@ -2,7 +2,8 @@ import {
   UPDATE_ADDRESSES,
   UPDATE_TX_HASH,
   SIGN_TX_ERROR,
-  POLL_FOR_CONFIRMATIONS_ERROR,
+  REDEMPTION_CONFIRMATION,
+  REDEMPTION_CONFIRMATION_ERROR,
   REDEMPTION_PROVE_BTC_TX_BEGIN,
   REDEMPTION_PROVE_BTC_TX_SUCCESS,
   REDEMPTION_PROVE_BTC_TX_ERROR,
@@ -20,7 +21,7 @@ const initialState = {
   txHash: null,
   requiredConfirmations: 1,
   confirmations: null,
-  pollForConfirmationsError: null,
+  confirmationError: null,
   redemption: null,
   isStateReady: false,
 }
@@ -58,10 +59,15 @@ const redemption = (state = initialState, action) => {
         ...state,
         txHash: action.payload.txHash,
       }
-    case POLL_FOR_CONFIRMATIONS_ERROR:
+    case REDEMPTION_CONFIRMATION:
       return {
         ...state,
-        pollForConfirmationsError: action.payload.pollForConfirmationsError,
+        confirmations: action.payload.confirmations,
+      }
+    case REDEMPTION_CONFIRMATION_ERROR:
+      return {
+        ...state,
+        confirmationError: action.payload.error,
       }
     case REDEMPTION_REQUESTED:
       return {

--- a/src/reducers/redemption.js
+++ b/src/reducers/redemption.js
@@ -2,6 +2,7 @@ import {
   UPDATE_ADDRESSES,
   UPDATE_TX_HASH,
   SIGN_TX_ERROR,
+  REDEMPTION_REQUIRED_CONFIRMATIONS,
   REDEMPTION_CONFIRMATION,
   REDEMPTION_CONFIRMATION_ERROR,
   REDEMPTION_PROVE_BTC_TX_BEGIN,
@@ -20,7 +21,7 @@ const initialState = {
   unsignedTransaction: null,
   txHash: null,
   requiredConfirmations: 1,
-  confirmations: null,
+  confirmations: 0,
   confirmationError: null,
   redemption: null,
   isStateReady: false,
@@ -58,6 +59,11 @@ const redemption = (state = initialState, action) => {
       return {
         ...state,
         txHash: action.payload.txHash,
+      }
+    case REDEMPTION_REQUIRED_CONFIRMATIONS:
+      return {
+        ...state,
+        requiredConfirmations: action.payload.requiredConfirmations,
       }
     case REDEMPTION_CONFIRMATION:
       return {

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -35,6 +35,7 @@ export const DEPOSIT_AUTO_SUBMIT_PROOF = "DEPOSIT_AUTO_SUBMIT_PROOF"
 
 export const BTC_TX_SEEN = "BTC_TX_SEEN"
 export const BTC_TX_ERROR = "BTC_TX_ERROR"
+export const BTC_TX_REQUIRED_CONFIRMATIONS = "BTC_TX_REQUIRED_CONFIRMATIONS"
 export const BTC_TX_CONFIRMED_WAIT = "BTC_TX_CONFIRMED_WAIT"
 export const BTC_TX_CONFIRMED = "BTC_TX_CONFIRMED"
 export const BTC_TX_CONFIRMED_ALL = "BTC_TX_CONFIRMED_ALL"
@@ -389,6 +390,14 @@ export function* autoSubmitDepositProof() {
   yield put(navigateTo("/deposit/" + deposit.address + "/pay/confirming"))
 
   try {
+    const requiredConfirmations = yield deposit.requiredConfirmations
+    yield put({
+      type: BTC_TX_REQUIRED_CONFIRMATIONS,
+      payload: {
+        requiredConfirmations,
+      },
+    })
+
     const confirmations = yield autoSubmission.fundingConfirmations
 
     yield put({

--- a/src/sagas/redemption.js
+++ b/src/sagas/redemption.js
@@ -13,6 +13,8 @@ import { logError } from "./lib"
 export const UPDATE_ADDRESSES = "UPDATE_ADDRESSES"
 export const UPDATE_TX_HASH = "UPDATE_TX_HASH"
 export const SIGN_TX_ERROR = "SIGN_TX_ERROR"
+export const REDEMPTION_REQUIRED_CONFIRMATIONS =
+  "REDEMPTION_REQUIRED_CONFIRMATIONS"
 export const REDEMPTION_CONFIRMATION = "REDEMPTION_CONFIRMATION"
 export const REDEMPTION_CONFIRMATION_ERROR = "REDEMPTION_CONFIRMATION_ERROR"
 export const REDEMPTION_REQUESTED = "REDEMPTION_REQUESTED"
@@ -153,11 +155,18 @@ function* runRedemption(redemption) {
 
   try {
     const txHash = yield autoSubmission.broadcastTransactionID
-
     yield put({
       type: UPDATE_TX_HASH,
       payload: {
         txHash,
+      },
+    })
+
+    const requiredConfirmations = yield redemption.deposit.requiredConfirmations
+    yield put({
+      type: REDEMPTION_REQUIRED_CONFIRMATIONS,
+      payload: {
+        requiredConfirmations,
       },
     })
 

--- a/src/sagas/redemption.js
+++ b/src/sagas/redemption.js
@@ -3,7 +3,8 @@ import { TBTCLoaded } from "../wrappers/web3"
 /** @typedef { import("@keep-network/tbtc.js").Redemption } Redemption */
 /** @typedef { import("@keep-network/tbtc.js").Deposit } Deposit */
 
-import { call, put, select } from "redux-saga/effects"
+import { call, put, select, take, delay, fork } from "redux-saga/effects"
+import { eventChannel, END } from "redux-saga"
 
 import { navigateTo } from "../lib/router/actions"
 import { DEPOSIT_RESOLVED } from "./deposit"
@@ -12,7 +13,8 @@ import { logError } from "./lib"
 export const UPDATE_ADDRESSES = "UPDATE_ADDRESSES"
 export const UPDATE_TX_HASH = "UPDATE_TX_HASH"
 export const SIGN_TX_ERROR = "SIGN_TX_ERROR"
-export const POLL_FOR_CONFIRMATIONS_ERROR = "POLL_FOR_CONFIRMATIONS_ERROR"
+export const REDEMPTION_CONFIRMATION = "REDEMPTION_CONFIRMATION"
+export const REDEMPTION_CONFIRMATION_ERROR = "REDEMPTION_CONFIRMATION_ERROR"
 export const REDEMPTION_REQUESTED = "REDEMPTION_REQUESTED"
 export const REDEMPTION_REQUEST_ERROR = "REDEMPTION_REQUEST_ERROR"
 export const REDEMPTION_PROVE_BTC_TX_BEGIN = "REDEMPTION_PROVE_BTC_TX_BEGIN"
@@ -94,12 +96,58 @@ export function* resumeRedemption() {
   }
 }
 
+function createConfirmationChannel(redemption) {
+  return eventChannel((emit) => {
+    const listener = ({
+      transactionID,
+      confirmations,
+      requiredConfirmations,
+    }) => {
+      emit({ transactionID, confirmations, requiredConfirmations })
+
+      // Close channel once we have all the required confirmations
+      if (confirmations === requiredConfirmations) {
+        emit(END)
+      }
+    }
+
+    redemption.onReceivedConfirmation(listener)
+
+    // no-op
+    // eventChannel subscriber must return an unsubscribe, but tbtc.js does not
+    // currently provide one
+    return () => {}
+  })
+}
+
+function* watchForConfirmations(redemption) {
+  yield delay(500)
+
+  const confirmationChannel = yield call(createConfirmationChannel, redemption)
+  try {
+    while (true) {
+      const { confirmations } = yield take(confirmationChannel)
+      yield delay(50)
+      if (confirmations) {
+        yield put({
+          type: REDEMPTION_CONFIRMATION,
+          payload: { confirmations },
+        })
+      }
+    }
+  } finally {
+    console.debug("And now, the watch has ended")
+  }
+}
+
 /**
  * @param {Redemption} redemption
  */
 function* runRedemption(redemption) {
   const autoSubmission = redemption.autoSubmit()
   const depositAddress = redemption.deposit.address
+
+  yield fork(watchForConfirmations, redemption)
 
   yield put(navigateTo("/deposit/" + depositAddress + "/redemption/signing"))
 
@@ -126,7 +174,7 @@ function* runRedemption(redemption) {
 
     yield put(navigateTo("/deposit/" + depositAddress + "/redemption/prove"))
   } catch (error) {
-    yield* logError(POLL_FOR_CONFIRMATIONS_ERROR, error)
+    yield* logError(REDEMPTION_CONFIRMATION_ERROR, error)
     return
   }
 


### PR DESCRIPTION
[PR soundtrack 🎵 ](https://www.youtube.com/watch?v=ABYnqp-bxvg)

Clarifies how many Bitcoin confirmations we are waiting for and what the current count is for both the deposit and redemption flows.

Closes #297 

References tbtc.js changes in https://github.com/keep-network/tbtc.js/pull/80