### PR TITLE
Reset state when restarting flows

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -45,6 +45,12 @@ export function restoreRedemptionState(depositAddress) {
   }
 }
 
+export const RESET_STATE = "RESET_STATE"
+
+export function resetState() {
+  return { type: RESET_STATE }
+}
+
 // Deposit
 export const REQUEST_A_DEPOSIT = "REQUEST_A_DEPOSIT"
 

--- a/src/components/deposit/Start.js
+++ b/src/components/deposit/Start.js
@@ -5,7 +5,11 @@ import PropTypes from "prop-types"
 
 import history from "../../history"
 import { requestPermission } from "../../lib/notifications"
-import { selectLotSize, requestAvailableLotSizes } from "../../actions"
+import {
+  selectLotSize,
+  requestAvailableLotSizes,
+  resetState,
+} from "../../actions"
 import Description from "../lib/Description"
 import StatusIndicator from "../svgs/StatusIndicator"
 import BTCLogo from "../svgs/btclogo"
@@ -21,6 +25,7 @@ const handleClickPay = (evt) => {
 }
 
 const Start = ({
+  resetState,
   requestAvailableLotSizes,
   availableLotSizes = [],
   lotSize,
@@ -29,7 +34,8 @@ const Start = ({
 }) => {
   useEffect(() => {
     requestPermission()
-  }, [])
+    resetState()
+  }, [resetState])
 
   const { account } = useWeb3React()
 
@@ -72,6 +78,7 @@ const Start = ({
 }
 
 Start.propTypes = {
+  resetState: PropTypes.func,
   requestAvailableLotSizes: PropTypes.func,
   availableLotSizes: PropTypes.arrayOf(PropTypes.string),
   lotSize: PropTypes.string,
@@ -87,7 +94,7 @@ const mapStateToProps = ({ deposit }) => ({
 
 const mapDispatchToProps = (dispatch) => {
   return bindActionCreators(
-    { selectLotSize, requestAvailableLotSizes },
+    { selectLotSize, requestAvailableLotSizes, resetState },
     dispatch
   )
 }

--- a/src/components/redemption/Start.js
+++ b/src/components/redemption/Start.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 import classnames from "classnames"
 import { bindActionCreators } from "redux"
 import { connect } from "react-redux"
@@ -10,11 +10,11 @@ import StatusIndicator from "../svgs/StatusIndicator"
 import TLogo from "../svgs/tlogo"
 import Check from "../svgs/Check"
 import X from "../svgs/X"
-import { saveAddresses } from "../../actions"
+import { saveAddresses, resetState } from "../../actions"
 
 import web3 from "web3"
 
-const Start = ({ saveAddresses }) => {
+const Start = ({ saveAddresses, resetState }) => {
   const initialAddressState = {
     address: "",
     isValid: false,
@@ -22,6 +22,10 @@ const Start = ({ saveAddresses }) => {
   }
   const [depositAddress, setDepositAddress] = useState(initialAddressState)
   const [btcAddress, setBtcAddress] = useState(initialAddressState)
+
+  useEffect(() => {
+    resetState()
+  }, [resetState])
 
   const handleClickConfirm = (evt) => {
     evt.preventDefault()
@@ -126,12 +130,14 @@ const Start = ({ saveAddresses }) => {
 
 Start.propTypes = {
   saveAddresses: PropTypes.func,
+  resetState: PropTypes.func,
 }
 
 const mapDispatchToProps = (dispatch) => {
   return bindActionCreators(
     {
       saveAddresses,
+      resetState,
     },
     dispatch
   )

--- a/src/components/redemption/Start.js
+++ b/src/components/redemption/Start.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react"
+import React, { useState } from "react"
 import classnames from "classnames"
 import { bindActionCreators } from "redux"
 import { connect } from "react-redux"
@@ -14,41 +14,35 @@ import { saveAddresses } from "../../actions"
 
 import web3 from "web3"
 
-class Start extends Component {
-  state = {
-    depositAddress: "",
-    depositAddressIsValid: false,
-    btcAddress: "",
-    btcAddressIsValid: false,
+const Start = ({ saveAddresses }) => {
+  const initialAddressState = {
+    address: "",
+    isValid: false,
+    hasError: false,
   }
+  const [depositAddress, setDepositAddress] = useState(initialAddressState)
+  const [btcAddress, setBtcAddress] = useState(initialAddressState)
 
-  handleClickConfirm = (evt) => {
+  const handleClickConfirm = (evt) => {
     evt.preventDefault()
     evt.stopPropagation()
 
-    const { saveAddresses } = this.props
-    const { btcAddress, depositAddress } = this.state
-
     saveAddresses({
-      btcAddress,
-      depositAddress,
+      btcAddress: btcAddress.address,
+      depositAddress: depositAddress.address,
     })
   }
 
-  handleDepositAddressChange = (evt) => {
+  const handleDepositAddressChange = (evt) => {
     const address = evt.target.value
 
     const isValid = web3.utils.isAddress(address)
     const hasError = !isValid
 
-    this.setState({
-      depositAddress: address,
-      depositAddressIsValid: isValid,
-      depositAddressHasError: hasError,
-    })
+    setDepositAddress({ address, isValid, hasError })
   }
 
-  verifyBtcAddress = (btcAddress) => {
+  const verifyBtcAddress = (btcAddress) => {
     try {
       return BitcoinHelpers.Address.toScript(btcAddress)
     } catch (err) {
@@ -57,92 +51,77 @@ class Start extends Component {
     }
   }
 
-  handleBtcAddressChange = (evt) => {
+  const handleBtcAddressChange = (evt) => {
     // TODO: Validate btc address
     const address = evt.target.value
 
-    const isValid = this.verifyBtcAddress(address)
+    const isValid = verifyBtcAddress(address)
     const hasError = !isValid
 
-    this.setState({
-      btcAddress: address,
-      btcAddressIsValid: isValid,
-      btcAddressHasError: hasError,
-    })
+    setBtcAddress({ address, isValid, hasError })
   }
 
-  render() {
-    const {
-      depositAddress,
-      depositAddressIsValid,
-      depositAddressHasError,
-      btcAddress,
-      btcAddressIsValid,
-      btcAddressHasError,
-    } = this.state
-
-    return (
-      <div className="redemption-start">
-        <div className="page-top">
-          <StatusIndicator donut>
-            <TLogo height={100} width={100} />
-          </StatusIndicator>
+  return (
+    <div className="redemption-start">
+      <div className="page-top">
+        <StatusIndicator donut>
+          <TLogo height={100} width={100} />
+        </StatusIndicator>
+      </div>
+      <div className="page-body">
+        <div className="step">Step 1/6</div>
+        <div className="title">Redeem bond</div>
+        <hr />
+        <div className="description">
+          <div
+            className={classnames("paste-field", {
+              success: depositAddress.isValid,
+              alert: depositAddress.hasError,
+            })}
+          >
+            <label htmlFor="deposit-address">What was your TDT ID?</label>
+            <input
+              type="text"
+              id="deposit-address"
+              onChange={handleDepositAddressChange}
+              value={depositAddress.address}
+              placeholder="Enter TDT ID"
+            />
+            {depositAddress.isValid && <Check height="28px" width="28px" />}
+            {depositAddress.hasError && <X height="28px" width="28px" />}
+          </div>
+          <div
+            className={classnames("paste-field", {
+              success: btcAddress.isValid,
+              alert: btcAddress.hasError,
+            })}
+          >
+            <label htmlFor="btc-address">
+              Where should we send your Bitcoin?
+            </label>
+            <input
+              type="text"
+              id="btc-address"
+              onChange={handleBtcAddressChange}
+              value={btcAddress.address}
+              placeholder="Enter BTC Address"
+            />
+            {btcAddress.isValid && <Check height="28px" width="28px" />}
+            {btcAddress.hasError && <X height="28px" width="28px" />}
+          </div>
         </div>
-        <div className="page-body">
-          <div className="step">Step 1/6</div>
-          <div className="title">Redeem bond</div>
-          <hr />
-          <div className="description">
-            <div
-              className={classnames("paste-field", {
-                success: depositAddressIsValid,
-                alert: depositAddressHasError,
-              })}
-            >
-              <label htmlFor="deposit-address">What was your TDT ID?</label>
-              <input
-                type="text"
-                id="deposit-address"
-                onChange={this.handleDepositAddressChange}
-                value={depositAddress}
-                placeholder="Enter TDT ID"
-              />
-              {depositAddressIsValid && <Check height="28px" width="28px" />}
-              {depositAddressHasError && <X height="28px" width="28px" />}
-            </div>
-            <div
-              className={classnames("paste-field", {
-                success: btcAddressIsValid,
-                alert: btcAddressHasError,
-              })}
-            >
-              <label htmlFor="btc-address">
-                Where should we send your Bitcoin?
-              </label>
-              <input
-                type="text"
-                id="btc-address"
-                onChange={this.handleBtcAddressChange}
-                value={btcAddress}
-                placeholder="Enter BTC Address"
-              />
-              {btcAddressIsValid && <Check height="28px" width="28px" />}
-              {btcAddressHasError && <X height="28px" width="28px" />}
-            </div>
-          </div>
-          <div className="cta">
-            <button
-              onClick={this.handleClickConfirm}
-              disabled={!depositAddressIsValid || !btcAddressIsValid}
-              className="black"
-            >
-              Redeem
-            </button>
-          </div>
+        <div className="cta">
+          <button
+            onClick={handleClickConfirm}
+            disabled={!depositAddress.isValid || !btcAddress.isValid}
+            className="black"
+          >
+            Redeem
+          </button>
         </div>
       </div>
-    )
-  }
+    </div>
+  )
 }
 
 Start.propTypes = {

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -76,6 +76,7 @@ const deposit = (state = initialState, action) => {
       return {
         ...state,
         invoiceStatus: 1,
+        requestDepositError: null,
       }
     case DEPOSIT_REQUEST_SUCCESS:
       return {
@@ -99,7 +100,7 @@ const deposit = (state = initialState, action) => {
       return {
         ...state,
         btcAddress: action.payload.btcAddress,
-        btcAddressError: undefined,
+        btcAddressError: null,
       }
     case DEPOSIT_BTC_ADDRESS_ERROR:
     case DEPOSIT_BTC_AMOUNTS_ERROR:
@@ -117,6 +118,7 @@ const deposit = (state = initialState, action) => {
       return {
         ...state,
         didSubmitDepositProof: true,
+        btcTxError: null,
       }
     case BTC_TX_SEEN:
       return {
@@ -133,6 +135,7 @@ const deposit = (state = initialState, action) => {
       return {
         ...state,
         btcConfirming: true,
+        btcConfirmingError: null,
       }
     case BTC_TX_REQUIRED_CONFIRMATIONS:
       return {

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -23,7 +23,7 @@ import {
   DEPOSIT_AVAILABLE_LOT_SIZES_REQUESTED,
   DEPOSIT_AVAILABLE_LOT_SIZES_ERROR,
 } from "../sagas/deposit"
-import { RESTORE_DEPOSIT_STATE, SELECT_LOT_SIZE } from "../actions"
+import { RESET_STATE, RESTORE_DEPOSIT_STATE, SELECT_LOT_SIZE } from "../actions"
 
 const initialState = {
   btcAddress: null,
@@ -44,6 +44,8 @@ const initialState = {
 
 const deposit = (state = initialState, action) => {
   switch (action.type) {
+    case RESET_STATE:
+      return initialState
     case RESTORE_DEPOSIT_STATE:
       return {
         ...state,

--- a/src/reducers/deposit.js
+++ b/src/reducers/deposit.js
@@ -24,6 +24,7 @@ import {
   DEPOSIT_AVAILABLE_LOT_SIZES_ERROR,
 } from "../sagas/deposit"
 import { RESET_STATE, RESTORE_DEPOSIT_STATE, SELECT_LOT_SIZE } from "../actions"
+import { HISTORY_PUSH } from "../lib/router/actions"
 
 const initialState = {
   btcAddress: null,
@@ -158,14 +159,14 @@ const deposit = (state = initialState, action) => {
       return {
         ...state,
         provingDeposit: true,
-        proveDepositError: undefined,
+        proveDepositError: null,
       }
     case DEPOSIT_PROVE_BTC_TX_SUCCESS:
       return {
         ...state,
         tbtcMintedTxID: action.payload.tbtcMintedTxID,
         provingDeposit: false,
-        proveDepositError: undefined,
+        proveDepositError: null,
       }
     case DEPOSIT_PROVE_BTC_TX_ERROR:
     case DEPOSIT_MINT_TBTC_ERROR:
@@ -173,6 +174,16 @@ const deposit = (state = initialState, action) => {
         ...state,
         provingDeposit: false,
         proveDepositError: action.payload.error,
+      }
+    case HISTORY_PUSH:
+      return {
+        ...state,
+        lotSizeError: null,
+        requestDepositError: null,
+        btcAddressError: null,
+        btcTxError: null,
+        btcConfirmingError: null,
+        proveDepositError: null,
       }
     default:
       return state

--- a/src/reducers/redemption.js
+++ b/src/reducers/redemption.js
@@ -12,7 +12,7 @@ import {
   REDEMPTION_REQUEST_ERROR,
 } from "../sagas/redemption"
 
-import { RESTORE_REDEMPTION_STATE } from "../actions"
+import { RESTORE_REDEMPTION_STATE, RESET_STATE } from "../actions"
 import { DEPOSIT_STATE_RESTORED, DEPOSIT_RESOLVED } from "../sagas/deposit"
 
 const initialState = {
@@ -34,6 +34,8 @@ const redemption = (state = initialState, action) => {
         ...state,
         depositAddress: action.payload.depositAddress,
       }
+    case RESET_STATE:
+      return initialState
     case DEPOSIT_STATE_RESTORED:
       return {
         ...state,

--- a/src/reducers/redemption.js
+++ b/src/reducers/redemption.js
@@ -67,6 +67,7 @@ const redemption = (state = initialState, action) => {
       return {
         ...state,
         requiredConfirmations: action.payload.requiredConfirmations,
+        confirmationError: null,
       }
     case REDEMPTION_CONFIRMATION:
       return {
@@ -82,6 +83,8 @@ const redemption = (state = initialState, action) => {
       return {
         ...state,
         redemption: action.payload.redemption,
+        requestRedemptionError: null,
+        signTxError: null,
       }
     case REDEMPTION_REQUEST_ERROR:
       return {

--- a/src/reducers/redemption.js
+++ b/src/reducers/redemption.js
@@ -13,6 +13,7 @@ import {
 } from "../sagas/redemption"
 
 import { RESTORE_REDEMPTION_STATE, RESET_STATE } from "../actions"
+import { HISTORY_PUSH } from "../lib/router/actions"
 import { DEPOSIT_STATE_RESTORED, DEPOSIT_RESOLVED } from "../sagas/deposit"
 
 const initialState = {
@@ -91,19 +92,27 @@ const redemption = (state = initialState, action) => {
       return {
         ...state,
         provingRedemption: true,
-        proveRedemptionError: undefined,
+        proveRedemptionError: null,
       }
     case REDEMPTION_PROVE_BTC_TX_SUCCESS:
       return {
         ...state,
         provingRedemption: false,
-        proveRedemptionError: undefined,
+        proveRedemptionError: null,
       }
     case REDEMPTION_PROVE_BTC_TX_ERROR:
       return {
         ...state,
         provingRedemption: false,
         proveRedemptionError: action.payload.error,
+      }
+    case HISTORY_PUSH:
+      return {
+        ...state,
+        requestRedemptionError: null,
+        signTxError: null,
+        confirmationError: null,
+        proveRedemptionError: null,
       }
     default:
       return state

--- a/src/reducers/redemption.js
+++ b/src/reducers/redemption.js
@@ -29,13 +29,13 @@ const initialState = {
 
 const redemption = (state = initialState, action) => {
   switch (action.type) {
+    case RESET_STATE:
+      return initialState
     case RESTORE_REDEMPTION_STATE:
       return {
         ...state,
         depositAddress: action.payload.depositAddress,
       }
-    case RESET_STATE:
-      return initialState
     case DEPOSIT_STATE_RESTORED:
       return {
         ...state,


### PR DESCRIPTION
Adds a new action to reset state when starting a deposit or redemption flow. The action is triggered in a `useEffect` so it should run on page load or when hitting the back button. 

Also clears any errors from the state when the `HISTORY_PUSH` action occurs. Note this action only happens when the history is modified programmatically via `navigateTo` and not when the user hits the back button in the browser. We also try to clear errors when logical. For instance, the `requestDepositError` will be reset in the state when a new deposit request is sent. 

Lastly, there is a little refactoring here to rewrite the `Start` component as a functional component.