### PR TITLE
Double trouble: De-duplicate the confirmation code

### DIFF
--- a/src/components/deposit/Confirming.js
+++ b/src/components/deposit/Confirming.js
@@ -17,10 +17,12 @@ const Confirming = ({
     error={error}
     requiredConfirmations={requiredConfirmations}
     confirmations={confirmations}
-    extraMessage="We’ll send
-    you a browser notification when your TBTC is ready to be minted."
   >
     <div>
+      <p>
+        We’ll send you a browser notification when your TBTC is ready to be
+        minted.
+      </p>
       <p>
         <i>A watched block never boils.</i>
       </p>

--- a/src/components/deposit/Confirming.js
+++ b/src/components/deposit/Confirming.js
@@ -2,8 +2,7 @@ import React from "react"
 import { connect } from "react-redux"
 import PropTypes from "prop-types"
 
-import Description from "../lib/Description"
-import StatusIndicator from "../svgs/StatusIndicator"
+import ConfirmingBase from "../lib/Confirming"
 import { formatSatsToBtc } from "../../utils"
 
 const Confirming = ({
@@ -11,39 +10,27 @@ const Confirming = ({
   error,
   requiredConfirmations,
   confirmations,
-}) => {
-  return (
-    <div className="pay pay-confirming">
-      <div className="page-top">
-        <StatusIndicator pulse />
-      </div>
-      <div className="page-body">
-        <div className="step">Step 3/5</div>
-        <div className="title">
-          {error ? "Error confirming transaction" : "Confirming..."}
-        </div>
-        <hr />
-        <Description error={error}>
-          <div>
-            Waiting for {requiredConfirmations} transaction{" "}
-            {`confirmation${requiredConfirmations > 1 ? "s" : ""}`}. We’ll send
-            you a browser notification when your TBTC is ready to be minted.
-            <p>
-              {confirmations} / {requiredConfirmations} blocks confirmed
-            </p>
-            <p>
-              <i>A watched block never boils.</i>
-            </p>
-          </div>
-          <div className="signer-fee">
-            <span className="signer-fee-label">Signer Fee: </span>
-            {signerFee} BTC*
-          </div>
-        </Description>
-      </div>
+}) => (
+  <ConfirmingBase
+    className="pay pay-confirming"
+    stepStatus="3/5"
+    error={error}
+    requiredConfirmations={requiredConfirmations}
+    confirmations={confirmations}
+    extraMessage="We’ll send
+    you a browser notification when your TBTC is ready to be minted."
+  >
+    <div>
+      <p>
+        <i>A watched block never boils.</i>
+      </p>
     </div>
-  )
-}
+    <div className="signer-fee">
+      <span className="signer-fee-label">Signer Fee: </span>
+      {signerFee} BTC*
+    </div>
+  </ConfirmingBase>
+)
 
 Confirming.propTypes = {
   signerFee: PropTypes.string,

--- a/src/components/lib/Confirming.js
+++ b/src/components/lib/Confirming.js
@@ -1,0 +1,56 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+import Description from "./Description"
+import StatusIndicator from "../svgs/StatusIndicator"
+
+const Confirming = ({
+  className,
+  stepStatus,
+  error,
+  requiredConfirmations,
+  confirmations,
+  children,
+  extraMessage,
+}) => {
+  return (
+    <div className={className}>
+      <div className="page-top">
+        <StatusIndicator pulse />
+      </div>
+      <div className="page-body">
+        <div className="step">Step {stepStatus}</div>
+        <div className="title">
+          {error ? "Error confirming transaction" : "Confirming..."}
+        </div>
+        <hr />
+        <Description error={error}>
+          <div>
+            Waiting for {requiredConfirmations} transaction{" "}
+            {`confirmation${requiredConfirmations > 1 ? "s" : ""}`}.{" "}
+            {extraMessage}
+            <p>
+              {confirmations} / {requiredConfirmations} blocks confirmed
+            </p>
+          </div>
+          {children}
+        </Description>
+      </div>
+    </div>
+  )
+}
+
+Confirming.propTypes = {
+  className: PropTypes.string,
+  stepStatus: PropTypes.string,
+  error: PropTypes.string,
+  requiredConfirmations: PropTypes.number,
+  confirmations: PropTypes.number,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+  extraMessage: PropTypes.string,
+}
+
+export default Confirming

--- a/src/components/lib/Confirming.js
+++ b/src/components/lib/Confirming.js
@@ -11,7 +11,6 @@ const Confirming = ({
   requiredConfirmations,
   confirmations,
   children,
-  extraMessage,
 }) => {
   return (
     <div className={className}>
@@ -27,8 +26,7 @@ const Confirming = ({
         <Description error={error}>
           <div>
             Waiting for {requiredConfirmations} transaction{" "}
-            {`confirmation${requiredConfirmations > 1 ? "s" : ""}`}.{" "}
-            {extraMessage}
+            {`confirmation${requiredConfirmations > 1 ? "s" : ""}`}.
             <p>
               {confirmations} / {requiredConfirmations} blocks confirmed
             </p>
@@ -50,7 +48,6 @@ Confirming.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
-  extraMessage: PropTypes.string,
 }
 
 export default Confirming

--- a/src/components/lib/index.js
+++ b/src/components/lib/index.js
@@ -1,7 +1,8 @@
+import Confirming from "./Confirming"
 import Description from "./Description"
 import Footer from "./Footer"
 import Header from "./Header"
 import Modal from "./Modal"
 import Web3Status from "./Web3Status"
 
-export { Description, Footer, Header, Modal, Web3Status }
+export { Confirming, Description, Footer, Header, Modal, Web3Status }

--- a/src/components/redemption/Confirming.js
+++ b/src/components/redemption/Confirming.js
@@ -2,8 +2,7 @@ import React from "react"
 import { connect } from "react-redux"
 import PropTypes from "prop-types"
 
-import Description from "../lib/Description"
-import StatusIndicator from "../svgs/StatusIndicator"
+import ConfirmingBase from "../lib/Confirming"
 
 const Confirming = ({
   txHash,
@@ -17,38 +16,21 @@ const Confirming = ({
   }tx/${txHash}`
 
   return (
-    <div className="confirming">
-      <div className="page-top">
-        <StatusIndicator pulse />
-      </div>
-      <div className="page-body">
-        <div className="step">Step 4/6</div>
-        <div className="title">
-          {error ? "Error confirming transaction" : "Confirming..."}
-        </div>
-        <hr />
-        <Description error={error}>
-          <p>
-            Waiting for {requiredConfirmations} transaction{" "}
-            {`confirmation${requiredConfirmations > 1 ? "s" : ""}`}.
-          </p>
-          <p>
-            {confirmations} / {requiredConfirmations} blocks confirmed
-          </p>
-          {txHash ? (
-            <a
-              href={blockExplorerUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Follow along in block explorer
-            </a>
-          ) : (
-            ""
-          )}
-        </Description>
-      </div>
-    </div>
+    <ConfirmingBase
+      className="confirming"
+      stepStatus="4/6"
+      error={error}
+      requiredConfirmations={requiredConfirmations}
+      confirmations={confirmations}
+    >
+      {txHash ? (
+        <a href={blockExplorerUrl} target="_blank" rel="noopener noreferrer">
+          Follow along in block explorer
+        </a>
+      ) : (
+        ""
+      )}
+    </ConfirmingBase>
   )
 }
 

--- a/src/sagas/lib/index.js
+++ b/src/sagas/lib/index.js
@@ -1,4 +1,5 @@
-import { put } from "redux-saga/effects"
+import { put, call, delay, take } from "redux-saga/effects"
+import { eventChannel, END } from "redux-saga"
 
 export function* logError(errorActionType, error) {
   const { message, reason, stack } = error
@@ -14,4 +15,50 @@ export function* logError(errorActionType, error) {
     originalStack: stack.split("\n").map((s) => s.trim()),
     error,
   })
+}
+
+export function createConfirmationChannel(flow, onConfirmed) {
+  return eventChannel((emit) => {
+    const listener = ({
+      transactionID,
+      confirmations,
+      requiredConfirmations,
+    }) => {
+      emit({ transactionID, confirmations, requiredConfirmations })
+
+      // Close channel once we have all the required confirmations
+      if (confirmations === requiredConfirmations) {
+        emit(END)
+      }
+    }
+
+    flow[onConfirmed](listener)
+
+    // no-op
+    // eventChannel subscriber must return an unsubscribe, but tbtc.js does not
+    // currently provide one
+    return () => {}
+  })
+}
+
+export function* watchForConfirmations(flow, onConfirmed, confirmedActionType) {
+  const confirmationChannel = yield call(
+    createConfirmationChannel,
+    flow,
+    onConfirmed
+  )
+  try {
+    while (true) {
+      const { transactionID, confirmations } = yield take(confirmationChannel)
+      yield delay(50)
+      if (confirmations) {
+        yield put({
+          type: confirmedActionType,
+          payload: { btcConfirmedTxID: transactionID, confirmations },
+        })
+      }
+    }
+  } finally {
+    console.debug("And now, the watch has ended")
+  }
 }


### PR DESCRIPTION
Creates a shared base `Confirming` component to be used in both the deposit and redemption flows. Also cleans up the sagas by moving the functionality to watch for confirmation events into the shared saga lib. 

Ready once #354 is merged.