### PR TITLE
Slick Moves: Set up tBTC config by chain id

### DIFF
--- a/src/config/config.json
+++ b/src/config/config.json
@@ -1,24 +1,26 @@
 {
-    "electrum": {
-      "testnet": {
-        "server": "electrumx-server.test.tbtc.network",
-        "port": 8443,
-        "protocol": "wss"
-      },
-      "testnetTCP": {
-        "server": "electrumx-server.test.tbtc.network",
-        "port": 50002,
-        "protocol": "ssl"
-      },
-      "mainnet": {
+  "1": {
+    "bitcoinNetwork": "main",
+      "electrum": {
         "server": "electrumx-server.tbtc.network",
         "port": 8443,
         "protocol": "wss"
-      },
-      "mainnetTCP": {
-        "server": "electrumx-server.tbtc.network",
-        "port": 50002,
-        "protocol": "ssl"
       }
+  },
+  "3": {
+    "bitcoinNetwork": "testnet",
+    "electrum": {
+        "server": "electrumx-server.test.tbtc.network",
+        "port": 8443,
+        "protocol": "wss"
     }
+  },
+  "1101": {
+    "bitcoinNetwork": "regtest",
+    "electrum": {
+        "server": "127.0.0.1",
+        "port": 50003,
+        "protocol": "ws"
+    }
+  }
 }

--- a/src/wrappers/web3.js
+++ b/src/wrappers/web3.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react"
 import Web3 from "web3"
-import TBTC, { EthereumHelpers, BitcoinHelpers } from "@keep-network/tbtc.js"
+import TBTC from "@keep-network/tbtc.js"
 import { Web3ReactProvider, useWeb3React } from "@web3-react/core"
 import { connect } from "react-redux"
 import { bindActionCreators } from "redux"
@@ -52,17 +52,12 @@ const initializeContracts = async (web3, connector, onTBTCLoaded) => {
 
   Web3LoadedDeferred.resolve(web3)
 
-  const tbtc = (await EthereumHelpers.isMainnet(web3))
-    ? await TBTC.withConfig({
-        web3: web3,
-        bitcoinNetwork: BitcoinHelpers.Network.MAINNET,
-        electrum: config.electrum.mainnet,
-      })
-    : await TBTC.withConfig({
-        web3: web3,
-        bitcoinNetwork: BitcoinHelpers.Network.TESTNET,
-        electrum: config.electrum.testnet,
-      })
+  const currentConfig = config[chainId.toString()]
+  const tbtc = await TBTC.withConfig({
+    web3: web3,
+    bitcoinNetwork: currentConfig.bitcoinNetwork,
+    electrum: currentConfig.electrum,
+  })
 
   TBTCLoadedDeferred.resolve(tbtc)
 


### PR DESCRIPTION
Rather than using isMainnet, provide a config indexed by chain id, and
use the already-looked-up chain id to determine which config to use at
load time. Config also now includes the local network.

Spinoff of keep-network/local-setup#40, though it doesn't block that PR.

In draft because I haven't had a chance to give it a full test yet, but if the
reviewer tests it satisfactorily I think we can land it. Whoever gets to it
first can review :wink: