### PR TITLE
Nip Tuck: Apply a few mainnet tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1516,9 +1516,9 @@
                     "integrity": "sha512-88M8RkVHl44k6MAhfrYhx25opnJV24/2XpuTUVklID11f9rBdE+6RZ9OMs39dyX2sDv7TuzIPi5nTRoCqZMDYw=="
                 },
                 "@types/node": {
-                    "version": "12.12.60",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.60.tgz",
-                    "integrity": "sha512-K/bfUP5mHMvfnxNd5GT9JFiqFSY9qA7x7iIiab4kCoyHmk31NXrS5jLq4p4JJa1t7p0dmBDyR6xOcmvOKtzrbg=="
+                    "version": "12.12.62",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
+                    "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
                 },
                 "cross-fetch": {
                     "version": "3.0.4",
@@ -1530,11 +1530,11 @@
                     }
                 },
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                    "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "eth-lib": {
@@ -2480,9 +2480,9 @@
             }
         },
         "@keep-network/tbtc.js": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/@keep-network/tbtc.js/-/tbtc.js-0.18.0.tgz",
-            "integrity": "sha512-8PaVYvZSMspQOyuHyGfHM+LMRLq7WbvbGSLxR6RUP4/EIyB00bDKLm2EsTtBUTzDpCyrC2+eweCDSaNBKT5nww==",
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/@keep-network/tbtc.js/-/tbtc.js-0.18.1.tgz",
+            "integrity": "sha512-dMH7UI258x0F5pjUiG25aZ14zaxVGDQ/CaVzrJRo7C0u04/rIwHcvVo87L7IQwDZ68+hWqwcgDFDSIlghLv2iw==",
             "requires": {
                 "@keep-network/keep-ecdsa": "1.2.1",
                 "@keep-network/tbtc": "1.1.0",
@@ -2729,9 +2729,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.12.60",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.60.tgz",
-                    "integrity": "sha512-K/bfUP5mHMvfnxNd5GT9JFiqFSY9qA7x7iIiab4kCoyHmk31NXrS5jLq4p4JJa1t7p0dmBDyR6xOcmvOKtzrbg=="
+                    "version": "12.12.62",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
+                    "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
                 },
                 "bignumber.js": {
                     "version": "7.2.1",
@@ -5631,9 +5631,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.12.60",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.60.tgz",
-                    "integrity": "sha512-K/bfUP5mHMvfnxNd5GT9JFiqFSY9qA7x7iIiab4kCoyHmk31NXrS5jLq4p4JJa1t7p0dmBDyR6xOcmvOKtzrbg=="
+                    "version": "12.12.62",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
+                    "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
                 }
             }
         },
@@ -29312,9 +29312,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.12.60",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.60.tgz",
-                    "integrity": "sha512-K/bfUP5mHMvfnxNd5GT9JFiqFSY9qA7x7iIiab4kCoyHmk31NXrS5jLq4p4JJa1t7p0dmBDyR6xOcmvOKtzrbg=="
+                    "version": "12.12.62",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
+                    "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
                 },
                 "bn.js": {
                     "version": "4.11.8",
@@ -29842,9 +29842,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.12.60",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.60.tgz",
-                    "integrity": "sha512-K/bfUP5mHMvfnxNd5GT9JFiqFSY9qA7x7iIiab4kCoyHmk31NXrS5jLq4p4JJa1t7p0dmBDyR6xOcmvOKtzrbg=="
+                    "version": "12.12.62",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
+                    "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
                 },
                 "bn.js": {
                     "version": "4.11.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "tbtc-dapp",
     "version": "0.17.1",
     "dependencies": {
-        "@keep-network/tbtc.js": "0.18.0",
+        "@keep-network/tbtc.js": "0.18.1",
         "@0x/subproviders": "^6.0.8",
         "@ledgerhq/hw-app-eth": "^5.12.2",
         "@ledgerhq/hw-transport-u2f": "^5.11.0",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -19,7 +19,13 @@ function App(props) {
           </p>
           <p>
             For more information and options please{" "}
-            <a href="https://discord.gg/Bpzfsgx">visit our Discord community</a>
+            <a
+              href="https://discord.gg/Bpzfsgx"
+              target="_blank"
+              rel="noreferrer"
+            >
+              visit our Discord community ↗
+            </a>
             .
           </p>
         </div>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -20,7 +20,7 @@ function App(props) {
           <p>
             For more information and options please{" "}
             <a
-              href="https://discord.gg/Bpzfsgx"
+              href="https://chat.tbtc.network/"
               target="_blank"
               rel="noreferrer"
             >

--- a/src/sagas/deposit.js
+++ b/src/sagas/deposit.js
@@ -63,7 +63,7 @@ function* restoreState(nextStepMap, stateKey) {
       },
     })
 
-    /** @type {BN} */
+    /** @type {number} */
     const depositState = yield call([deposit, deposit.getCurrentState])
 
     const nextStep = nextStepMap[depositState]
@@ -122,10 +122,19 @@ function* restoreState(nextStepMap, stateKey) {
         break
 
       // Funding failure states
-      case tbtc.Deposit.State.FRAUD_AWAITING_BTC_FUNDING_PROOF:
       case tbtc.Deposit.State.FAILED_SETUP:
-        // TODO Update deposit state to reflect situation.
-        break
+        throw new Error(
+          `Deposit has failed setup. Please try opening a new deposit.`
+        )
+
+      case tbtc.Deposit.State.COURTESY_CALL:
+      case tbtc.Deposit.State.LIQUIDATION_IN_PROGRESS:
+      case tbtc.Deposit.State.FRAUD_LIQUIDATION_IN_PROGRESS:
+      case tbtc.Deposit.State.LIQUIDATED:
+        throw new Error(
+          `Deposit is in a liquidation state. This dApp currently does not ` +
+            `support managing deposit liquidation.`
+        )
 
       default:
         throw new Error(`Unexpected state ${depositState}.`)


### PR DESCRIPTION
This PR does a few small things:

 - Includes the fixes from tbtc.js 0.18.1, around retries and redemption fees.
 - Makes the Discord link in the dApp open in a new tab, as folks were getting
   worried when they ran into trouble and the link navigated them away from the
   dApp (even though the dApp responds well to back buttons).
 - Clarifies errors when a deposit is in a liquidation or failed setup state.
