### PR TITLE
Allow an initial deposit address to be given via query string.

### DIFF
--- a/src/components/redemption/Start.js
+++ b/src/components/redemption/Start.js
@@ -3,6 +3,7 @@ import classnames from "classnames"
 import { bindActionCreators } from "redux"
 import { connect } from "react-redux"
 import PropTypes from "prop-types"
+import { useParams } from "react-router-dom"
 import { useWeb3React } from "@web3-react/core"
 
 import { BitcoinHelpers } from "@keep-network/tbtc.js"
@@ -21,12 +22,26 @@ const Start = ({ saveAddresses, resetState, openWalletModal }) => {
     isValid: false,
     hasError: false,
   }
-  const [depositAddress, setDepositAddress] = useState(initialAddressState)
+
+  const params = useParams()
+
+  const [depositAddress, setDepositAddress] = useState({
+    ...initialAddressState,
+    address: params.address || "",
+  })
   const [btcAddress, setBtcAddress] = useState(initialAddressState)
 
   useEffect(() => {
     resetState()
   }, [resetState])
+
+  useEffect(() => {
+    if (depositAddress.address) {
+      const isValid = web3.utils.isAddress(depositAddress.address)
+      const hasError = !isValid
+      setDepositAddress({ address: depositAddress.address, isValid, hasError })
+    }
+  }, [])
 
   const { active } = useWeb3React()
 

--- a/src/index.js
+++ b/src/index.js
@@ -98,6 +98,11 @@ function AppWrapper() {
               </Loadable>
             </Route>
             <Route path="/redeem" exact component={StartRedemption} />
+            <Route
+              path="/deposit/:address/redeem"
+              exact
+              component={StartRedemption}
+            />
             <Route path="/deposit/:address/redemption" exact>
               <Loadable restorer={RESTORER.REDEMPTION}>
                 <Redeeming />


### PR DESCRIPTION
This allows the start the redemption flow with a deposit address already prefilled, for example:

```
http://localhost:3001/redeem/?deposit=0xecfdabdd933799e524e5e21c6672213a1f22e9dd
```

This would enable third party websites & explorer to link to the redemption flow for deposits they know are redeemable.

Pinging @mhluongo as this was his idea.