### PR TITLE
Bump web3 dependency to v1.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2416,19 +2416,95 @@
             "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
         },
         "@ethersproject/abi": {
-            "version": "5.0.0-beta.153",
-            "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz",
-            "integrity": "sha512-aXweZ1Z7vMNzJdLpR1CZUAIgnwjrZeUSvN9syCwlBaEBUFJmFY+HHnfuTI5vIhVs/mRkfJVrbEyl51JZQqyjAg==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.7.tgz",
+            "integrity": "sha512-Cqktk+hSIckwP/W8O47Eef60VwmoSC/L3lY0+dIBhQPCNn9E4V7rwmm2aFrNRRDJfFlGuZ1khkQUOc3oBX+niw==",
             "requires": {
-                "@ethersproject/address": ">=5.0.0-beta.128",
-                "@ethersproject/bignumber": ">=5.0.0-beta.130",
-                "@ethersproject/bytes": ">=5.0.0-beta.129",
-                "@ethersproject/constants": ">=5.0.0-beta.128",
-                "@ethersproject/hash": ">=5.0.0-beta.128",
-                "@ethersproject/keccak256": ">=5.0.0-beta.127",
-                "@ethersproject/logger": ">=5.0.0-beta.129",
-                "@ethersproject/properties": ">=5.0.0-beta.131",
-                "@ethersproject/strings": ">=5.0.0-beta.130"
+                "@ethersproject/address": "^5.0.4",
+                "@ethersproject/bignumber": "^5.0.7",
+                "@ethersproject/bytes": "^5.0.4",
+                "@ethersproject/constants": "^5.0.4",
+                "@ethersproject/hash": "^5.0.4",
+                "@ethersproject/keccak256": "^5.0.3",
+                "@ethersproject/logger": "^5.0.5",
+                "@ethersproject/properties": "^5.0.3",
+                "@ethersproject/strings": "^5.0.4"
+            },
+            "dependencies": {
+                "@ethersproject/address": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.1.0.tgz",
+                    "integrity": "sha512-rfWQR12eHn2cpstCFS4RF7oGjfbkZb0oqep+BfrT+gWEGWG2IowJvIsacPOvzyS1jhNF4MQ4BS59B04Mbovteg==",
+                    "requires": {
+                        "@ethersproject/bignumber": "^5.1.0",
+                        "@ethersproject/bytes": "^5.1.0",
+                        "@ethersproject/keccak256": "^5.1.0",
+                        "@ethersproject/logger": "^5.1.0",
+                        "@ethersproject/rlp": "^5.1.0"
+                    }
+                },
+                "@ethersproject/bignumber": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.1.1.tgz",
+                    "integrity": "sha512-AVz5iqz7+70RIqoQTznsdJ6DOVBYciNlvO+AlQmPTB6ofCvoihI9bQdr6wljsX+d5W7Yc4nyvQvP4JMzg0Agig==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.1.0",
+                        "@ethersproject/logger": "^5.1.0",
+                        "bn.js": "^4.4.0"
+                    }
+                },
+                "@ethersproject/bytes": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.1.0.tgz",
+                    "integrity": "sha512-sGTxb+LVjFxJcJeUswAIK6ncgOrh3D8c192iEJd7mLr95V6du119rRfYT/b87WPkZ5I3gRBUYIYXtdgCWACe8g==",
+                    "requires": {
+                        "@ethersproject/logger": "^5.1.0"
+                    }
+                },
+                "@ethersproject/constants": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.1.0.tgz",
+                    "integrity": "sha512-0/SuHrxc8R8k+JiLmJymxHJbojUDWBQqO+b+XFdwaP0jGzqC09YDy/CAlSZB6qHsBifY8X3I89HcK/oMqxRdBw==",
+                    "requires": {
+                        "@ethersproject/bignumber": "^5.1.0"
+                    }
+                },
+                "@ethersproject/keccak256": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.1.0.tgz",
+                    "integrity": "sha512-vrTB1W6AEYoadww5c9UyVJ2YcSiyIUTNDRccZIgwTmFFoSHwBtcvG1hqy9RzJ1T0bMdATbM9Hfx2mJ6H0i7Hig==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.1.0",
+                        "js-sha3": "0.5.7"
+                    }
+                },
+                "@ethersproject/logger": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.1.0.tgz",
+                    "integrity": "sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw=="
+                },
+                "@ethersproject/properties": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.1.0.tgz",
+                    "integrity": "sha512-519KKTwgmH42AQL3+GFV3SX6khYEfHsvI6v8HYejlkigSDuqttdgVygFTDsGlofNFchhDwuclrxQnD5B0YLNMg==",
+                    "requires": {
+                        "@ethersproject/logger": "^5.1.0"
+                    }
+                },
+                "@ethersproject/rlp": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.1.0.tgz",
+                    "integrity": "sha512-vDTyHIwNPrecy55gKGZ47eJZhBm8LLBxihzi5ou+zrSvYTpkSTWRcKUlXFDFQVwfWB+P5PGyERAdiDEI76clxw==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.1.0",
+                        "@ethersproject/logger": "^5.1.0"
+                    }
+                },
+                "js-sha3": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+                    "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+                }
             }
         },
         "@ethersproject/abstract-provider": {
@@ -2671,14 +2747,86 @@
             }
         },
         "@ethersproject/hash": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.2.tgz",
-            "integrity": "sha512-dWGvNwmVRX2bxoQQ3ciMw46Vzl1nqfL+5R8+2ZxsRXD3Cjgw1dL2mdjJF7xMMWPvPdrlhKXWSK0gb8VLwHZ8Cw==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.1.0.tgz",
+            "integrity": "sha512-fNwry20yLLPpnRRwm3fBL+2ksgO+KMadxM44WJmRIoTKzy4269+rbq9KFoe2LTqq2CXJM2CE70beGaNrpuqflQ==",
             "requires": {
-                "@ethersproject/bytes": "^5.0.0",
-                "@ethersproject/keccak256": "^5.0.0",
-                "@ethersproject/logger": "^5.0.0",
-                "@ethersproject/strings": "^5.0.0"
+                "@ethersproject/abstract-signer": "^5.1.0",
+                "@ethersproject/address": "^5.1.0",
+                "@ethersproject/bignumber": "^5.1.0",
+                "@ethersproject/bytes": "^5.1.0",
+                "@ethersproject/keccak256": "^5.1.0",
+                "@ethersproject/logger": "^5.1.0",
+                "@ethersproject/properties": "^5.1.0",
+                "@ethersproject/strings": "^5.1.0"
+            },
+            "dependencies": {
+                "@ethersproject/address": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.1.0.tgz",
+                    "integrity": "sha512-rfWQR12eHn2cpstCFS4RF7oGjfbkZb0oqep+BfrT+gWEGWG2IowJvIsacPOvzyS1jhNF4MQ4BS59B04Mbovteg==",
+                    "requires": {
+                        "@ethersproject/bignumber": "^5.1.0",
+                        "@ethersproject/bytes": "^5.1.0",
+                        "@ethersproject/keccak256": "^5.1.0",
+                        "@ethersproject/logger": "^5.1.0",
+                        "@ethersproject/rlp": "^5.1.0"
+                    }
+                },
+                "@ethersproject/bignumber": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.1.1.tgz",
+                    "integrity": "sha512-AVz5iqz7+70RIqoQTznsdJ6DOVBYciNlvO+AlQmPTB6ofCvoihI9bQdr6wljsX+d5W7Yc4nyvQvP4JMzg0Agig==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.1.0",
+                        "@ethersproject/logger": "^5.1.0",
+                        "bn.js": "^4.4.0"
+                    }
+                },
+                "@ethersproject/bytes": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.1.0.tgz",
+                    "integrity": "sha512-sGTxb+LVjFxJcJeUswAIK6ncgOrh3D8c192iEJd7mLr95V6du119rRfYT/b87WPkZ5I3gRBUYIYXtdgCWACe8g==",
+                    "requires": {
+                        "@ethersproject/logger": "^5.1.0"
+                    }
+                },
+                "@ethersproject/keccak256": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.1.0.tgz",
+                    "integrity": "sha512-vrTB1W6AEYoadww5c9UyVJ2YcSiyIUTNDRccZIgwTmFFoSHwBtcvG1hqy9RzJ1T0bMdATbM9Hfx2mJ6H0i7Hig==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.1.0",
+                        "js-sha3": "0.5.7"
+                    }
+                },
+                "@ethersproject/logger": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.1.0.tgz",
+                    "integrity": "sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw=="
+                },
+                "@ethersproject/properties": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.1.0.tgz",
+                    "integrity": "sha512-519KKTwgmH42AQL3+GFV3SX6khYEfHsvI6v8HYejlkigSDuqttdgVygFTDsGlofNFchhDwuclrxQnD5B0YLNMg==",
+                    "requires": {
+                        "@ethersproject/logger": "^5.1.0"
+                    }
+                },
+                "@ethersproject/rlp": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.1.0.tgz",
+                    "integrity": "sha512-vDTyHIwNPrecy55gKGZ47eJZhBm8LLBxihzi5ou+zrSvYTpkSTWRcKUlXFDFQVwfWB+P5PGyERAdiDEI76clxw==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.1.0",
+                        "@ethersproject/logger": "^5.1.0"
+                    }
+                },
+                "js-sha3": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+                    "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+                }
             }
         },
         "@ethersproject/keccak256": {
@@ -2746,13 +2894,46 @@
             }
         },
         "@ethersproject/strings": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.2.tgz",
-            "integrity": "sha512-oNa+xvSqsFU96ndzog0IBTtsRFGOqGpzrXJ7shXLBT7juVeSEyZA/sYs0DMZB5mJ9FEjHdZKxR/rTyBY91vuXg==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.1.0.tgz",
+            "integrity": "sha512-perBZy0RrmmL0ejiFGUOlBVjMsUceqLut3OBP3zP96LhiJWWbS8u1NqQVgN4/Gyrbziuda66DxiQocXhsvx+Sw==",
             "requires": {
-                "@ethersproject/bytes": "^5.0.0",
-                "@ethersproject/constants": "^5.0.0",
-                "@ethersproject/logger": "^5.0.0"
+                "@ethersproject/bytes": "^5.1.0",
+                "@ethersproject/constants": "^5.1.0",
+                "@ethersproject/logger": "^5.1.0"
+            },
+            "dependencies": {
+                "@ethersproject/bignumber": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.1.1.tgz",
+                    "integrity": "sha512-AVz5iqz7+70RIqoQTznsdJ6DOVBYciNlvO+AlQmPTB6ofCvoihI9bQdr6wljsX+d5W7Yc4nyvQvP4JMzg0Agig==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.1.0",
+                        "@ethersproject/logger": "^5.1.0",
+                        "bn.js": "^4.4.0"
+                    }
+                },
+                "@ethersproject/bytes": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.1.0.tgz",
+                    "integrity": "sha512-sGTxb+LVjFxJcJeUswAIK6ncgOrh3D8c192iEJd7mLr95V6du119rRfYT/b87WPkZ5I3gRBUYIYXtdgCWACe8g==",
+                    "requires": {
+                        "@ethersproject/logger": "^5.1.0"
+                    }
+                },
+                "@ethersproject/constants": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.1.0.tgz",
+                    "integrity": "sha512-0/SuHrxc8R8k+JiLmJymxHJbojUDWBQqO+b+XFdwaP0jGzqC09YDy/CAlSZB6qHsBifY8X3I89HcK/oMqxRdBw==",
+                    "requires": {
+                        "@ethersproject/bignumber": "^5.1.0"
+                    }
+                },
+                "@ethersproject/logger": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.1.0.tgz",
+                    "integrity": "sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw=="
+                }
             }
         },
         "@ethersproject/transactions": {
@@ -6851,7 +7032,7 @@
                 "bcrypto": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.3.0",
                 "bsert": "git+https://github.com/chjj/bsert.git#semver:~0.0.10",
                 "bufio": "git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6",
-                "loady": "git+https://github.com/chjj/loady.git#semver:~0.0.1"
+                "loady": "loady@git+https://github.com/chjj/loady.git#b94958b7ee061518f4b85ea6da380e7ee93222d5"
             },
             "dependencies": {
                 "bufio": {
@@ -30451,23 +30632,23 @@
             }
         },
         "web3": {
-            "version": "1.2.11",
-            "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.11.tgz",
-            "integrity": "sha512-mjQ8HeU41G6hgOYm1pmeH0mRAeNKJGnJEUzDMoerkpw7QUQT4exVREgF1MYPvL/z6vAshOXei25LE/t/Bxl8yQ==",
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.5.tgz",
+            "integrity": "sha512-UyQW/MT5EIGBrXPCh/FDIaD7RtJTn5/rJUNw2FOglp0qoXnCQHNKvntiR1ylztk05fYxIF6UgsC76IrazlKJjw==",
             "requires": {
-                "web3-bzz": "1.2.11",
-                "web3-core": "1.2.11",
-                "web3-eth": "1.2.11",
-                "web3-eth-personal": "1.2.11",
-                "web3-net": "1.2.11",
-                "web3-shh": "1.2.11",
-                "web3-utils": "1.2.11"
+                "web3-bzz": "1.3.5",
+                "web3-core": "1.3.5",
+                "web3-eth": "1.3.5",
+                "web3-eth-personal": "1.3.5",
+                "web3-net": "1.3.5",
+                "web3-shh": "1.3.5",
+                "web3-utils": "1.3.5"
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.12.54",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.54.tgz",
-                    "integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w=="
+                    "version": "12.20.12",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.12.tgz",
+                    "integrity": "sha512-KQZ1al2hKOONAs2MFv+yTQP1LkDWMrRJ9YCVRalXltOfXsBmH5IownLxQaiq0lnAHwAViLnh2aTYqrPcRGEbgg=="
                 },
                 "decompress-response": {
                     "version": "3.3.0",
@@ -30491,6 +30672,14 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
                     "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+                },
+                "oboe": {
+                    "version": "2.1.5",
+                    "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.5.tgz",
+                    "integrity": "sha1-VVQoTFQ6ImbXo48X4HOCH73jk80=",
+                    "requires": {
+                        "http-https": "^1.0.0"
+                    }
                 },
                 "p-cancelable": {
                     "version": "0.3.0",
@@ -30551,15 +30740,28 @@
                         "prepend-http": "^1.0.1"
                     }
                 },
+                "util": {
+                    "version": "0.12.3",
+                    "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+                    "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "is-arguments": "^1.0.4",
+                        "is-generator-function": "^1.0.7",
+                        "is-typed-array": "^1.1.3",
+                        "safe-buffer": "^5.1.2",
+                        "which-typed-array": "^1.1.2"
+                    }
+                },
                 "uuid": {
                     "version": "3.3.2",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
                     "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
                 },
                 "web3-bzz": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.11.tgz",
-                    "integrity": "sha512-XGpWUEElGypBjeFyUhTkiPXFbDVD6Nr/S5jznE3t8cWUA0FxRf1n3n/NuIZeb0H9RkN2Ctd/jNma/k8XGa3YKg==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.5.tgz",
+                    "integrity": "sha512-XiEUAbB1uKm/agqfwBsCW8fbw+sma85TfwuDpdcy591vinVk0S9TfWgLxro6v1KJ6nSELySIbKGbAJbh2GSyxw==",
                     "requires": {
                         "@types/node": "^12.12.6",
                         "got": "9.6.0",
@@ -30568,106 +30770,107 @@
                     }
                 },
                 "web3-core": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.11.tgz",
-                    "integrity": "sha512-CN7MEYOY5ryo5iVleIWRE3a3cZqVaLlIbIzDPsvQRUfzYnvzZQRZBm9Mq+ttDi2STOOzc1MKylspz/o3yq/LjQ==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.5.tgz",
+                    "integrity": "sha512-VQjTvnGTqJwDwjKEHSApea3RmgtFGLDSJ6bqrOyHROYNyTyKYjFQ/drG9zs3rjDkND9mgh8foI1ty37Qua3QCQ==",
                     "requires": {
                         "@types/bn.js": "^4.11.5",
                         "@types/node": "^12.12.6",
                         "bignumber.js": "^9.0.0",
-                        "web3-core-helpers": "1.2.11",
-                        "web3-core-method": "1.2.11",
-                        "web3-core-requestmanager": "1.2.11",
-                        "web3-utils": "1.2.11"
+                        "web3-core-helpers": "1.3.5",
+                        "web3-core-method": "1.3.5",
+                        "web3-core-requestmanager": "1.3.5",
+                        "web3-utils": "1.3.5"
                     }
                 },
                 "web3-core-helpers": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.11.tgz",
-                    "integrity": "sha512-PEPoAoZd5ME7UfbnCZBdzIerpe74GEvlwT4AjOmHeCVZoIFk7EqvOZDejJHt+feJA6kMVTdd0xzRNN295UhC1A==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.5.tgz",
+                    "integrity": "sha512-HYh3ix5FjysgT0jyzD8s/X5ym0b4BGU7I2QtuBiydMnE0mQEWy7GcT9XKpTySA8FTOHHIAQYvQS07DN/ky3UzA==",
                     "requires": {
                         "underscore": "1.9.1",
-                        "web3-eth-iban": "1.2.11",
-                        "web3-utils": "1.2.11"
+                        "web3-eth-iban": "1.3.5",
+                        "web3-utils": "1.3.5"
                     }
                 },
                 "web3-core-method": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.11.tgz",
-                    "integrity": "sha512-ff0q76Cde94HAxLDZ6DbdmKniYCQVtvuaYh+rtOUMB6kssa5FX0q3vPmixi7NPooFnbKmmZCM6NvXg4IreTPIw==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.5.tgz",
+                    "integrity": "sha512-hCbmgQ+At6OTuaNGAdjXMsCr4eUCmp9yGKSuaB5HdkNVDpqFso4HHjVxcjNrTyJp3OZnyjKBzQzK1ZWLpLl84Q==",
                     "requires": {
                         "@ethersproject/transactions": "^5.0.0-beta.135",
                         "underscore": "1.9.1",
-                        "web3-core-helpers": "1.2.11",
-                        "web3-core-promievent": "1.2.11",
-                        "web3-core-subscriptions": "1.2.11",
-                        "web3-utils": "1.2.11"
+                        "web3-core-helpers": "1.3.5",
+                        "web3-core-promievent": "1.3.5",
+                        "web3-core-subscriptions": "1.3.5",
+                        "web3-utils": "1.3.5"
                     }
                 },
                 "web3-core-promievent": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.11.tgz",
-                    "integrity": "sha512-il4McoDa/Ox9Agh4kyfQ8Ak/9ABYpnF8poBLL33R/EnxLsJOGQG2nZhkJa3I067hocrPSjEdlPt/0bHXsln4qA==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.5.tgz",
+                    "integrity": "sha512-K0j8x3ZJr0eAyNvyUCxOUsSTd4hco0/9nxxlyOuijcsa6YV8l9NL6eqhniWbSyxCJT8ka5Mb7yAiUZe69EDLBQ==",
                     "requires": {
                         "eventemitter3": "4.0.4"
                     }
                 },
                 "web3-core-requestmanager": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.11.tgz",
-                    "integrity": "sha512-oFhBtLfOiIbmfl6T6gYjjj9igOvtyxJ+fjS+byRxiwFJyJ5BQOz4/9/17gWR1Cq74paTlI7vDGxYfuvfE/mKvA==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.5.tgz",
+                    "integrity": "sha512-9l294U3Ga8qmvv8E37BqjQREfMs+kFnkU3PY28g9DZGYzKvl3V1dgDYqxyrOBdCFhc7rNSpHdgC4PrVHjouspg==",
                     "requires": {
                         "underscore": "1.9.1",
-                        "web3-core-helpers": "1.2.11",
-                        "web3-providers-http": "1.2.11",
-                        "web3-providers-ipc": "1.2.11",
-                        "web3-providers-ws": "1.2.11"
+                        "util": "^0.12.0",
+                        "web3-core-helpers": "1.3.5",
+                        "web3-providers-http": "1.3.5",
+                        "web3-providers-ipc": "1.3.5",
+                        "web3-providers-ws": "1.3.5"
                     }
                 },
                 "web3-core-subscriptions": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.11.tgz",
-                    "integrity": "sha512-qEF/OVqkCvQ7MPs1JylIZCZkin0aKK9lDxpAtQ1F8niEDGFqn7DT8E/vzbIa0GsOjL2fZjDhWJsaW+BSoAW1gg==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.5.tgz",
+                    "integrity": "sha512-6mtXdaEB1V1zKLqYBq7RF2W75AK5ZJNGpW6QYC7Zvbku7zq1ZlgaUkJo88JKMWJ7etfaHaYqQ/7VveHk5sQynA==",
                     "requires": {
                         "eventemitter3": "4.0.4",
                         "underscore": "1.9.1",
-                        "web3-core-helpers": "1.2.11"
+                        "web3-core-helpers": "1.3.5"
                     }
                 },
                 "web3-eth": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.11.tgz",
-                    "integrity": "sha512-REvxW1wJ58AgHPcXPJOL49d1K/dPmuw4LjPLBPStOVkQjzDTVmJEIsiLwn2YeuNDd4pfakBwT8L3bz1G1/wVsQ==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.5.tgz",
+                    "integrity": "sha512-5qqDPMMD+D0xRqOV2ePU2G7/uQmhn0FgCEhFzKDMHrssDQJyQLW/VgfA0NLn64lWnuUrGnQStGvNxrWf7MgsfA==",
                     "requires": {
                         "underscore": "1.9.1",
-                        "web3-core": "1.2.11",
-                        "web3-core-helpers": "1.2.11",
-                        "web3-core-method": "1.2.11",
-                        "web3-core-subscriptions": "1.2.11",
-                        "web3-eth-abi": "1.2.11",
-                        "web3-eth-accounts": "1.2.11",
-                        "web3-eth-contract": "1.2.11",
-                        "web3-eth-ens": "1.2.11",
-                        "web3-eth-iban": "1.2.11",
-                        "web3-eth-personal": "1.2.11",
-                        "web3-net": "1.2.11",
-                        "web3-utils": "1.2.11"
+                        "web3-core": "1.3.5",
+                        "web3-core-helpers": "1.3.5",
+                        "web3-core-method": "1.3.5",
+                        "web3-core-subscriptions": "1.3.5",
+                        "web3-eth-abi": "1.3.5",
+                        "web3-eth-accounts": "1.3.5",
+                        "web3-eth-contract": "1.3.5",
+                        "web3-eth-ens": "1.3.5",
+                        "web3-eth-iban": "1.3.5",
+                        "web3-eth-personal": "1.3.5",
+                        "web3-net": "1.3.5",
+                        "web3-utils": "1.3.5"
                     }
                 },
                 "web3-eth-abi": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.11.tgz",
-                    "integrity": "sha512-PkRYc0+MjuLSgg03QVWqWlQivJqRwKItKtEpRUaxUAeLE7i/uU39gmzm2keHGcQXo3POXAbOnMqkDvOep89Crg==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.5.tgz",
+                    "integrity": "sha512-bkbG2v/mOW5DH6rF/SEgqunusjYoEi2IBw+fkmD3rzWDaEY7+/i1xY94AeO257d06QMgld75GtV/N+aEs7A6vQ==",
                     "requires": {
-                        "@ethersproject/abi": "5.0.0-beta.153",
+                        "@ethersproject/abi": "5.0.7",
                         "underscore": "1.9.1",
-                        "web3-utils": "1.2.11"
+                        "web3-utils": "1.3.5"
                     }
                 },
                 "web3-eth-accounts": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.11.tgz",
-                    "integrity": "sha512-6FwPqEpCfKIh3nSSGeo3uBm2iFSnFJDfwL3oS9pyegRBXNsGRVpgiW63yhNzL0796StsvjHWwQnQHsZNxWAkGw==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.5.tgz",
+                    "integrity": "sha512-r3WOR21rgm6Cd6OFnifr3Tizdm5K+g2TsSOPySwX4FrgLrYDL6ck4zr5VXUPz+llpSExb/JztpE8pqEHr3U2NA==",
                     "requires": {
                         "crypto-browserify": "3.12.0",
                         "eth-lib": "0.2.8",
@@ -30676,10 +30879,10 @@
                         "scrypt-js": "^3.0.1",
                         "underscore": "1.9.1",
                         "uuid": "3.3.2",
-                        "web3-core": "1.2.11",
-                        "web3-core-helpers": "1.2.11",
-                        "web3-core-method": "1.2.11",
-                        "web3-utils": "1.2.11"
+                        "web3-core": "1.3.5",
+                        "web3-core-helpers": "1.3.5",
+                        "web3-core-method": "1.3.5",
+                        "web3-utils": "1.3.5"
                     },
                     "dependencies": {
                         "eth-lib": {
@@ -30695,119 +30898,147 @@
                     }
                 },
                 "web3-eth-contract": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.11.tgz",
-                    "integrity": "sha512-MzYuI/Rq2o6gn7vCGcnQgco63isPNK5lMAan2E51AJLknjSLnOxwNY3gM8BcKoy4Z+v5Dv00a03Xuk78JowFow==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.5.tgz",
+                    "integrity": "sha512-WfGVeQquN3D7Qm+KEIN9EI7yrm/fL2V9Y4+YhDWiKA/ns1pX1LYcEWojTOnBXCnPF3tcvoKKL+KBxXg1iKm38A==",
                     "requires": {
                         "@types/bn.js": "^4.11.5",
                         "underscore": "1.9.1",
-                        "web3-core": "1.2.11",
-                        "web3-core-helpers": "1.2.11",
-                        "web3-core-method": "1.2.11",
-                        "web3-core-promievent": "1.2.11",
-                        "web3-core-subscriptions": "1.2.11",
-                        "web3-eth-abi": "1.2.11",
-                        "web3-utils": "1.2.11"
+                        "web3-core": "1.3.5",
+                        "web3-core-helpers": "1.3.5",
+                        "web3-core-method": "1.3.5",
+                        "web3-core-promievent": "1.3.5",
+                        "web3-core-subscriptions": "1.3.5",
+                        "web3-eth-abi": "1.3.5",
+                        "web3-utils": "1.3.5"
                     }
                 },
                 "web3-eth-ens": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.11.tgz",
-                    "integrity": "sha512-dbW7dXP6HqT1EAPvnniZVnmw6TmQEKF6/1KgAxbo8iBBYrVTMDGFQUUnZ+C4VETGrwwaqtX4L9d/FrQhZ6SUiA==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.5.tgz",
+                    "integrity": "sha512-5bkpFTXV18CvaVP8kCbLZZm2r1TWUv9AsXH+80yz8bTZulUGvXsBMRfK6e5nfEr2Yv59xlIXCFoalmmySI9EJw==",
                     "requires": {
                         "content-hash": "^2.5.2",
                         "eth-ens-namehash": "2.0.8",
                         "underscore": "1.9.1",
-                        "web3-core": "1.2.11",
-                        "web3-core-helpers": "1.2.11",
-                        "web3-core-promievent": "1.2.11",
-                        "web3-eth-abi": "1.2.11",
-                        "web3-eth-contract": "1.2.11",
-                        "web3-utils": "1.2.11"
+                        "web3-core": "1.3.5",
+                        "web3-core-helpers": "1.3.5",
+                        "web3-core-promievent": "1.3.5",
+                        "web3-eth-abi": "1.3.5",
+                        "web3-eth-contract": "1.3.5",
+                        "web3-utils": "1.3.5"
                     }
                 },
                 "web3-eth-iban": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.11.tgz",
-                    "integrity": "sha512-ozuVlZ5jwFC2hJY4+fH9pIcuH1xP0HEFhtWsR69u9uDIANHLPQQtWYmdj7xQ3p2YT4bQLq/axKhZi7EZVetmxQ==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.5.tgz",
+                    "integrity": "sha512-x+BI/d2Vt0J1cKK8eFd4W0f1TDjgEOYCwiViTb28lLE+tqrgyPqWDA+l6UlKYLF/yMFX3Dym4ofcCOtgcn4q4g==",
                     "requires": {
                         "bn.js": "^4.11.9",
-                        "web3-utils": "1.2.11"
+                        "web3-utils": "1.3.5"
                     }
                 },
                 "web3-eth-personal": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.11.tgz",
-                    "integrity": "sha512-42IzUtKq9iHZ8K9VN0vAI50iSU9tOA1V7XU2BhF/tb7We2iKBVdkley2fg26TxlOcKNEHm7o6HRtiiFsVK4Ifw==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.5.tgz",
+                    "integrity": "sha512-xELQHNZ8p3VoO1582ghCaq+Bx7pSkOOalc6/ACOCGtHDMelqgVejrmSIZGScYl+k0HzngmQAzURZWQocaoGM1g==",
                     "requires": {
                         "@types/node": "^12.12.6",
-                        "web3-core": "1.2.11",
-                        "web3-core-helpers": "1.2.11",
-                        "web3-core-method": "1.2.11",
-                        "web3-net": "1.2.11",
-                        "web3-utils": "1.2.11"
+                        "web3-core": "1.3.5",
+                        "web3-core-helpers": "1.3.5",
+                        "web3-core-method": "1.3.5",
+                        "web3-net": "1.3.5",
+                        "web3-utils": "1.3.5"
                     }
                 },
                 "web3-net": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.11.tgz",
-                    "integrity": "sha512-sjrSDj0pTfZouR5BSTItCuZ5K/oZPVdVciPQ6981PPPIwJJkCMeVjD7I4zO3qDPCnBjBSbWvVnLdwqUBPtHxyg==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.5.tgz",
+                    "integrity": "sha512-usbFbuUpKK8s7jPLGoUzi/WpNnefGFPTj948aJv8BZ04UQA4L/XS5NNkkhk358zNMmhGfEFW8wrWy+0Oy0njtA==",
                     "requires": {
-                        "web3-core": "1.2.11",
-                        "web3-core-method": "1.2.11",
-                        "web3-utils": "1.2.11"
+                        "web3-core": "1.3.5",
+                        "web3-core-method": "1.3.5",
+                        "web3-utils": "1.3.5"
                     }
                 },
                 "web3-providers-http": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.11.tgz",
-                    "integrity": "sha512-psh4hYGb1+ijWywfwpB2cvvOIMISlR44F/rJtYkRmQ5jMvG4FOCPlQJPiHQZo+2cc3HbktvvSJzIhkWQJdmvrA==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.5.tgz",
+                    "integrity": "sha512-ZQOmceFjcajEZdiuqciXjijwIYWNmEJ1oxMtbrwB2eGxHRCMXEH2xGRUZuhOFNF88yQC/VXVi14yvYg5ZlFJlA==",
                     "requires": {
-                        "web3-core-helpers": "1.2.11",
+                        "web3-core-helpers": "1.3.5",
                         "xhr2-cookies": "1.1.0"
                     }
                 },
                 "web3-providers-ipc": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.11.tgz",
-                    "integrity": "sha512-yhc7Y/k8hBV/KlELxynWjJDzmgDEDjIjBzXK+e0rHBsYEhdCNdIH5Psa456c+l0qTEU2YzycF8VAjYpWfPnBpQ==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.5.tgz",
+                    "integrity": "sha512-cbZOeb/sALiHjzMolJjIyHla/J5wdL2JKUtRO66Nh/uLALBCpU8JUgzNvpAdJ1ae3+A33+EdFStdzuDYHKtQew==",
                     "requires": {
-                        "oboe": "2.1.4",
+                        "oboe": "2.1.5",
                         "underscore": "1.9.1",
-                        "web3-core-helpers": "1.2.11"
+                        "web3-core-helpers": "1.3.5"
                     }
                 },
                 "web3-providers-ws": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.11.tgz",
-                    "integrity": "sha512-ZxnjIY1Er8Ty+cE4migzr43zA/+72AF1myzsLaU5eVgdsfV7Jqx7Dix1hbevNZDKFlSoEyq/3j/jYalh3So1Zg==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.5.tgz",
+                    "integrity": "sha512-zeZ4LMvKhYaJBDCqA//Bzgp4r/T0tNq5U/xvN0axA4YflzF7yqlsbzGwCkcZYDbrUaK3Ltl2uOmvwjbWALOZ1A==",
                     "requires": {
                         "eventemitter3": "4.0.4",
                         "underscore": "1.9.1",
-                        "web3-core-helpers": "1.2.11",
-                        "websocket": "^1.0.31"
+                        "web3-core-helpers": "1.3.5",
+                        "websocket": "^1.0.32"
                     }
                 },
                 "web3-shh": {
-                    "version": "1.2.11",
-                    "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.11.tgz",
-                    "integrity": "sha512-B3OrO3oG1L+bv3E1sTwCx66injW1A8hhwpknDUbV+sw3fehFazA06z9SGXUefuFI1kVs4q2vRi0n4oCcI4dZDg==",
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.5.tgz",
+                    "integrity": "sha512-aRwzCduXvuGVslLL/Y15VcOHa70Qr2kxZI7UwOzQVhaaOdxuRRvo3AK/cmyln1Tsd54/n93Yk8I3qg5I2+6alw==",
                     "requires": {
-                        "web3-core": "1.2.11",
-                        "web3-core-method": "1.2.11",
-                        "web3-core-subscriptions": "1.2.11",
-                        "web3-net": "1.2.11"
+                        "web3-core": "1.3.5",
+                        "web3-core-method": "1.3.5",
+                        "web3-core-subscriptions": "1.3.5",
+                        "web3-net": "1.3.5"
+                    }
+                },
+                "web3-utils": {
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.5.tgz",
+                    "integrity": "sha512-5apMRm8ElYjI/92GHqijmaLC+s+d5lgjpjHft+rJSs/dsnX8I8tQreqev0dmU+wzU+2EEe4Sx9a/OwGWHhQv3A==",
+                    "requires": {
+                        "bn.js": "^4.11.9",
+                        "eth-lib": "0.2.8",
+                        "ethereum-bloom-filters": "^1.0.6",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randombytes": "^2.1.0",
+                        "underscore": "1.9.1",
+                        "utf8": "3.0.0"
+                    },
+                    "dependencies": {
+                        "eth-lib": {
+                            "version": "0.2.8",
+                            "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+                            "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+                            "requires": {
+                                "bn.js": "^4.11.6",
+                                "elliptic": "^6.4.0",
+                                "xhr-request-promise": "^0.1.2"
+                            }
+                        }
                     }
                 },
                 "websocket": {
-                    "version": "1.0.31",
-                    "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.31.tgz",
-                    "integrity": "sha512-VAouplvGKPiKFDTeCCO65vYHsyay8DqoBSlzIO3fayrfOgU94lQN5a1uWVnFrMLceTJw/+fQXR5PGbUVRaHshQ==",
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
+                    "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
                     "requires": {
+                        "bufferutil": "^4.0.1",
                         "debug": "^2.2.0",
                         "es5-ext": "^0.10.50",
-                        "nan": "^2.14.0",
                         "typedarray-to-buffer": "^3.1.5",
+                        "utf-8-validate": "^5.0.2",
                         "yaeti": "^0.0.6"
                     }
                 }
@@ -31626,6 +31857,19 @@
                 "underscore": "1.9.1",
                 "web3-core-helpers": "1.2.2",
                 "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+            },
+            "dependencies": {
+                "websocket": {
+                    "version": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
+                    "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+                    "requires": {
+                        "debug": "^2.2.0",
+                        "es5-ext": "^0.10.50",
+                        "nan": "^2.14.0",
+                        "typedarray-to-buffer": "^3.1.5",
+                        "yaeti": "^0.0.6"
+                    }
+                }
             }
         },
         "web3-shh": {
@@ -31640,9 +31884,9 @@
             }
         },
         "web3-utils": {
-            "version": "1.2.11",
-            "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
-            "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.5.tgz",
+            "integrity": "sha512-5apMRm8ElYjI/92GHqijmaLC+s+d5lgjpjHft+rJSs/dsnX8I8tQreqev0dmU+wzU+2EEe4Sx9a/OwGWHhQv3A==",
             "requires": {
                 "bn.js": "^4.11.9",
                 "eth-lib": "0.2.8",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "tbtc-dapp",
     "version": "0.17.6-pre",
     "dependencies": {
-        "@keep-network/tbtc.js": ">0.19.4-pre <0.19.4-rc",
         "@0x/subproviders": "^6.0.8",
+        "@keep-network/tbtc.js": ">0.19.4-pre <0.19.4-rc",
         "@ledgerhq/hw-app-eth": "^5.12.2",
         "@ledgerhq/hw-transport-u2f": "^5.11.0",
         "@ledgerhq/web3-subprovider": "^5.11.0",
@@ -28,9 +28,9 @@
         "redux-devtools-extension": "^2.13.8",
         "redux-saga": "^1.0.5",
         "trezor-connect": "^8.1.1",
-        "web3": "^1.2.6",
+        "web3": "^1.3.5",
         "web3-provider-engine": "^15.0.6",
-        "web3-utils": "^1.2.8"
+        "web3-utils": "^1.3.5"
     },
     "scripts": {
         "start-js": "react-scripts start",


### PR DESCRIPTION
Closes: #388 

Bump web3 dependencies to the latest version `v1.3.5` to address breaking changes in the
MetaMask API provided in v.9.
Details:
https://github.com/ChainSafe/web3.js/pull/3864
https://github.com/MetaMask/metamask-extension/issues/8077#issuecomment-765004856