### PR TITLE
Move publishing of Go client to GH Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,5 @@
+# GitHub Actions equivalent of this workflow  (.github/workflows/dapp.yml) 
+# has been created as part of work on RFC-18
 version: 2.1
 
 executors:

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -1,0 +1,100 @@
+name: Dapp
+
+on:
+  push:
+    branches:
+      # TODO: Run only on master after we're fully migrated from Circle CI
+      - "rfc-18/**"
+      - master
+    # TODO: paths:
+  pull_request:
+    branches:
+      # TODO: Run on all branches or only on master (to be decided) 
+      # after we're fully migrated from Circle CI
+      - "rfc-18/**"
+      - master
+    # TODO: paths:
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "12.x"
+      
+      - name: Resolve latest tbtc.js
+        run: npm update @keep-network/tbtc.js
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to Google Container Registry
+        if: | # remove 'rfc-18' condition once workflow tested
+            (startsWith(github.ref, 'refs/heads/rfc-18/')
+              || github.ref == 'refs/heads/master')
+              && (github.event_name == 'push'
+              || github.event_name == 'workflow_dispatch')
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.GCR_REGISTRY_URL }}
+          username: _json_key
+          password: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
+
+      - name: Build and publish Keep Token Dashboard image
+        uses: docker/build-push-action@v2
+        env:
+          IMAGE_NAME: 'tbtc-dapp-wip' # TODO: remove '-wip' once full workflow verified
+          GOOGLE_PROJECT_ID: ${{ secrets.KEEP_TEST_GOOGLE_PROJECT_ID }}
+        with:
+          target: build
+          # GCR image should be named according to following convention:
+          # HOSTNAME/PROJECT-ID/IMAGE:TAG
+          # We don't use TAG yet, will be added at later stages of work on RFC-18.
+          tags: ${{ secrets.GCR_REGISTRY_URL }}/${{ env.GOOGLE_PROJECT_ID }}/${{ env.IMAGE_NAME }}
+          labels: revision=${{ github.sha }}
+          push: | # remove 'rfc-18' condition once workflow tested
+            ${{ (startsWith(github.ref, 'refs/heads/rfc-18/')
+              || github.ref == 'refs/heads/master')
+              && (github.event_name == 'push'
+              || github.event_name == 'workflow_dispatch') }} 
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2 
+        with:
+          node-version: "12.x"
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-dapp-node-modules
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint


### PR DESCRIPTION
As described in RFC-18, there is a need for a refactorization of Keep
and tBTC release processes in order to reduce human involvement and to
make the process less error prone. A part of this task is migration
from CircleCI to GitHub Actions. This PR creates a GitHub Action
workflow for linting, building and publishing of tBTC Dapp.

The `build-and-publish` job is configured to execute only if
workflow is started by a push or workflow_dispatch event on master or
`rfc-18/*` branch. The `rfc-18/*` condition will need to be removed
once whole `build-test-migrate-publish-keep-test` CircleCI process gets
migrated to GH Actions.