### PR TITLE
Load non-sensitive data from file instead of from secrets

### DIFF
--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -36,12 +36,14 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/load-env-variables@main # TODO: use @v1 once availible
+        uses: keep-network/load-env-variables@v1
         env: 
           CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
+          # TODO: Consider passing of `environment` input instead of using 
+          # hardcoded value. Would require some rework in action's code or
+          # in config files.
           environment: 'ropsten'
-          ref: 'master'
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -35,6 +35,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Load environment variables
+        uses: keep-network/load-env-variables@main # TODO: use @v1 once availible
+        env: 
+          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        with:
+          environment: 'ropsten'
+          ref: 'master'
+
       - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
@@ -54,12 +62,13 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Login to Google Container Registry
-        if: |
-          github.ref == 'refs/heads/master'
-            && github.event_name != 'pull_request'
+        if: | # TODO: remove 'rfc-18' condition one tested
+          (github.ref == 'refs/heads/master'
+            && github.event_name != 'pull_request')
+            || github.ref == 'refs/heads/rfc-18/load-env-var'
         uses: docker/login-action@v1
         with:
-          registry: ${{ secrets.GCR_REGISTRY_URL }}
+          registry: ${{ env.GCR_REGISTRY_URL }}
           username: _json_key
           password: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
@@ -67,16 +76,16 @@ jobs:
         uses: docker/build-push-action@v2
         env:
           IMAGE_NAME: 'tbtc-dapp'
-          GOOGLE_PROJECT_ID: ${{ secrets.KEEP_TEST_GOOGLE_PROJECT_ID }}
         with:
           # GCR image should be named according to following convention:
           # HOSTNAME/PROJECT-ID/IMAGE:TAG
           # We don't use TAG yet, will be added at later stages of work on RFC-18.
-          tags: ${{ secrets.GCR_REGISTRY_URL }}/${{ env.GOOGLE_PROJECT_ID }}/${{ env.IMAGE_NAME }}
+          tags: ${{ env.GCR_REGISTRY_URL }}/${{ env.GOOGLE_PROJECT_ID }}/${{ env.IMAGE_NAME }}
           labels: revision=${{ github.sha }}
-          push: |
-            ${{ github.ref == 'refs/heads/master'
-              && github.event_name != 'pull_request' }}
+          push: | # TODO: remove 'rfc-18' condition one tested
+            ${{ (github.ref == 'refs/heads/master'
+              && github.event_name != 'pull_request')
+              || github.ref == 'refs/heads/rfc-18/load-env-var' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -62,10 +62,9 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Login to Google Container Registry
-        if: | # TODO: remove 'rfc-18' condition one tested
-          (github.ref == 'refs/heads/master'
-            && github.event_name != 'pull_request')
-            || github.ref == 'refs/heads/rfc-18/load-env-var'
+        if: |
+          github.ref == 'refs/heads/master'
+            && github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           registry: ${{ env.GCR_REGISTRY_URL }}
@@ -82,10 +81,9 @@ jobs:
           # We don't use TAG yet, will be added at later stages of work on RFC-18.
           tags: ${{ env.GCR_REGISTRY_URL }}/${{ env.GOOGLE_PROJECT_ID }}/${{ env.IMAGE_NAME }}
           labels: revision=${{ github.sha }}
-          push: | # TODO: remove 'rfc-18' condition one tested
-            ${{ (github.ref == 'refs/heads/master'
-              && github.event_name != 'pull_request')
-              || github.ref == 'refs/heads/rfc-18/load-env-var' }}
+          push: |
+            ${{ github.ref == 'refs/heads/master'
+              && github.event_name != 'pull_request' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 


### PR DESCRIPTION
Non-sensitive data previously accessed by using `secrets` context is
now accessed by invoking `keep-network/load-env-variables` action and
using `env` context.
BACKGROUND:
We've been storing id of the test environment as
`KEEP_TEST_ETH_NETWORK_ID` organization secret in GitHub's settings to
allow for easy access to that value from multiple projects.
But it turned out to be problematic, as GHA in some situations redacts
workflow logs and actions outputs/inputs based on the values stored in
secrets. So if the secret holds small numeric value, it is quite
probable that at some point in time this value will be recognized as a
substring of `github.sha` or another variable and the `github.sha` will
be redacted with `***` in place of the recognized pattern. If such
redacted value is configured as input of some action, the action gets
invoked by the GHA without that input, which can cause run failure or
can mess up the workflow results.
As a solution for this problem we decided to no longer store
frequently-used, non-sensitive data such as `KEEP_TEST_ETH_NETWORK_ID`
in GitHub's secrets, but instead store them in a file kept in
`keep-network/ci` repository and read that data to `env` context in
order to be able to use it when running workflows. A
`keep-network/load-env-variables` action has been implemented to allow
for loading of the variables to `env` context in one step. The scope of
the loaded variables is limited to the job in which they were loaded.
To use the variables in other job, action `load-env-variables` needs to
be executed there as well.