### PR TITLE
`ref` input renamed to `upstream_ref`

### DIFF
--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -17,7 +17,7 @@ on:
       upstream_builds:
         description: 'Upstream builds'
         required: false
-      ref:
+      upstream_ref:
         description: 'Git reference to checkout (e.g. branch name)'
         required: false
         default: 'master'
@@ -34,7 +34,7 @@ jobs:
             echo "Workflow dispatched on branch: ${{ github.ref }}"
             echo "environment = ${{ github.event.inputs.environment }}"
             echo "upstream_builds = ${{ github.event.inputs.upstream_builds }}"
-            echo "ref = ${{ github.event.inputs.ref }}"
+            echo "upstream_ref = ${{ github.event.inputs.upstream_ref }}"
             echo "sha = ${{ github.sha }}"
 
       - name: Show workflow metadata
@@ -139,7 +139,7 @@ jobs:
           url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           environment: ${{ github.event.inputs.environment }}
           upstream_builds: ${{ github.event.inputs.upstream_builds }}
-          ref: ${{ github.event.inputs.ref }}
+          upstream_ref: ${{ github.event.inputs.upstream_ref }}
           version: ${{ github.sha }}
 
   dapp-lint:


### PR DESCRIPTION
`ref` input renamed to `upstream_ref`

RFC-18 document calls the parameter for holding ref value
`upstream_ref`, we're changing the name to that to be consistent with
that document.
Same change will be applied also in other repositories.

Note: PR should be merged in parallel with rest of the PRs related to
the name change:
https://github.com/keep-network/ci#3
https://github.com/keep-network/run-workflow/pull/2
https://github.com/keep-network/notify-workflow-completed#1
https://github.com/keep-network/keep-core/pull/2466
https://github.com/keep-network/keep-ecdsa/pull/786
https://github.com/keep-network/tbtc/pull/793
https://github.com/keep-network/tbtc.js/pull/123