### PR TITLE
Manually updated loady dependency reference in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7054,7 +7054,7 @@
                 "bcrypto": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.3.0",
                 "bsert": "git+https://github.com/chjj/bsert.git#semver:~0.0.10",
                 "bufio": "git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6",
-                "loady": "loady@git+https://github.com/chjj/loady.git#b94958b7ee061518f4b85ea6da380e7ee93222d5"
+                "loady": "git+https://github.com/chjj/loady.git#b94958b7ee061518f4b85ea6da380e7ee93222d5"
             },
             "dependencies": {
                 "bufio": {


### PR DESCRIPTION
`npm install` command fails with error:
```
Could not install from
"node_modules/bfilter/loady@git+https:/github.com/chjj/loady.git#b94958b7ee061518f4b85ea6da380e7ee93222d5"
as it does not contain a package.json file.
```

At the same time `npm ci` works just fine.

With this commit we're manually updating `package-lock.json` to modify
an entry that seems to be broken. With this change `npm install` worked
fine.

Tested using: node v12.22.0 (npm v6.14.11)