### PR TITLE
No longer set CI_GITHUB_TOKEN for load-env-variables action

### DIFF
--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -50,8 +50,6 @@ jobs:
 
       - name: Load environment variables
         uses: keep-network/load-env-variables@v1
-        env: 
-          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
           # TODO: Consider passing of `environment` input instead of using 
           # hardcoded value. Would require some rework in action's code or


### PR DESCRIPTION
The `keep-network/ci` repository storing the config files used by the
`load-env-variables` action is no longer private. This means that we
no longer need to authenticate curl with the token allowing access to
the repository.

See also:
https://github.com/keep-network/keep-core/pull/2490
https://github.com/keep-network/keep-ecdsa/pull/818
https://github.com/keep-network/tbtc/pull/803