### PR TITLE
CI workflows - Move cache instead of copying

### DIFF
--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -110,7 +110,17 @@ jobs:
           labels: revision=${{ github.sha }}
           push: ${{ github.event_name == 'workflow_dispatch' }}
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - # Temp fix - move cache instead of copying (added below step and
+        # modified value of `cache-to`).
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        # Without the change some jobs were failing with `no space left on device`
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Notify CI about completion of the workflow
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -112,16 +112,6 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
-      - # Temp fix - move cache instead of copying (added below step and
-        # modified value of `cache-to`).
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        # Without the change some jobs were failing with `no space left on device`
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
       - name: Notify CI about completion of the workflow
         if: github.event_name == 'workflow_dispatch'
         uses: keep-network/notify-workflow-completed@v1
@@ -134,6 +124,16 @@ jobs:
           upstream_builds: ${{ github.event.inputs.upstream_builds }}
           upstream_ref: ${{ github.event.inputs.upstream_ref }}
           version: ${{ github.sha }}
+
+      - # Temp fix - move cache instead of copying (added below step and
+        # modified value of `cache-to`).
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        # Without the change some jobs were failing with `no space left on device`
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   dapp-lint:
     needs: dapp-detect-changes


### PR DESCRIPTION
In `keep-ecdsa` we've seen a number of workflows failing with `No space
lefton device` error.
The problem was a combination of a big cache size and significant memory
allocation after building Docker image.
According to moby/buildkit#1850:
"At the moment caches are copied over the existing cache so it keeps
growing".
As a temporary fix (until issue gets fixed by GH), we introduced a step
that moves the cache (similarily to how it's described in
moby/buildkit#1896) instead of copying.
Although we havent seen the problems with cache size yet in other
projects than `keep-ecdsa`, we're applying the solution across the
repositories to decrease the likelyhood of encountering problem in the
future.

See also:
https://github.com/keep-network/keep-ecdsa/pull/822
https://github.com/keep-network/keep-core/pull/2501
https://github.com/keep-network/tbtc/pull/807