### PR TITLE
Migrate from `master` to `main` branch

### DIFF
--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -3,7 +3,7 @@ name: Dapp
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - "docs/**"
       - "infrastructure/**"
@@ -20,7 +20,7 @@ on:
       upstream_ref:
         description: 'Git reference to checkout (e.g. branch name)'
         required: false
-        default: 'master'
+        default: 'main'
 
 jobs:
   dapp-detect-changes:

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -16,7 +16,7 @@ request.
 3. Follow the <<README.adoc#setup,installation & build steps>> in the
    repository's top-level README.
 4. Setup the recommended <<Development Tooling>>.
-5. Open a PR against the `master` branch and describe the change you are
+5. Open a PR against the `main` branch and describe the change you are
    intending to undertake in the PR description.
 
 Before marking the PR as ready for review, make sure:

--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,7 @@ toc::[]
 The dApp requires a version of the tbtc.js library corresponding to the
 environment being tested on. Versions with version `-pre*` are for the Keep
 internal testnet and _will not work_ with Ropsten. For Ropsten, look for
-versions of tbtc.js labeled `-rc*` instead. Clones of the`master` branch of
+versions of tbtc.js labeled `-rc*` instead. Clones of the`main` branch of
 this repository will by default use a `-pre*` version of the tbtc.js library;
 this version can be adjusted in the `package.json` file.
 


### PR DESCRIPTION
Use of the `master` and `slave` terms in the computer industry is
widespread, but has been recently discouraged, as it was brought to
attention that the terms may be considered offensive.
GitHub has already moved their default repositories from the `master`
to `main` in many places. We're planning to do the same for our
repositories, this however requires some changes in the code.
After the proposed changes get merged to the `master` branch, the
repository should be ready for the migration from `master` to `main`.

To migrate from `master` to `main`:
1. Do a local branch rename with `git branch -m master main`
2. Push the renamed branch `git push -u origin main`
3. In the Github repo settings, rename the default branch: Settings ->
    Branches -> Default branch -> (pencil icon) -> (change `master` to
    `main`) -> (approve)

After migration other contributors should update their local repositories:
```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

Refs:
https://github.com/keep-network/keep-core/pull/2521
https://github.com/keep-network/keep-ecdsa/pull/845
https://github.com/keep-network/tbtc/pull/810
https://github.com/keep-network/tbtc.js/pull/126
https://github.com/keep-network/keep-common/pull/79
https://github.com/keep-network/sortition-pools/pull/113
https://github.com/keep-network/local-setup/pull/97
https://github.com/keep-network/ci/pull/8
https://github.com/keep-network/run-workflow/pull/3
https://github.com/keep-network/notify-workflow-completed/pull/3
https://github.com/keep-network/load-env-variables/pull/2