### PR TITLE
Update custom actions paths after moving actions to `ci`

### DIFF
--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/load-env-variables@v1
+        uses: keep-network/ci/actions/load-env-variables@move-actions-to-ci # TODO: change to @v1 before merging to main
         with:
           # TODO: Consider passing of `environment` input instead of using 
           # hardcoded value. Would require some rework in action's code or
@@ -66,7 +66,7 @@ jobs:
 
       - name: Get upstream packages' versions
         if: github.event_name == 'workflow_dispatch'
-        uses: keep-network/upstream-builds-query@v1
+        uses: keep-network/ci/actions/upstream-builds-query@move-actions-to-ci # TODO: change to @v1 before merging to main
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -114,7 +114,7 @@ jobs:
 
       - name: Notify CI about completion of the workflow
         if: github.event_name == 'workflow_dispatch'
-        uses: keep-network/notify-workflow-completed@v1
+        uses: keep-network/ci/actions/notify-workflow-completed@move-actions-to-ci # TODO: change to @v1 before merging to main
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
       
       - name: Resolve latest tbtc.js
         if: github.event_name != 'workflow_dispatch'
@@ -146,7 +146,7 @@ jobs:
 
       - uses: actions/setup-node@v2 
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Cache node modules
         uses: actions/cache@v2

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -147,18 +147,7 @@ jobs:
       - uses: actions/setup-node@v2 
         with:
           node-version: "14.x"
-
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-dapp-node-modules
-        with:
-          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/ci/actions/load-env-variables@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/load-env-variables@v1
         with:
           # TODO: Consider passing of `environment` input instead of using 
           # hardcoded value. Would require some rework in action's code or
@@ -66,7 +66,7 @@ jobs:
 
       - name: Get upstream packages' versions
         if: github.event_name == 'workflow_dispatch'
-        uses: keep-network/ci/actions/upstream-builds-query@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/upstream-builds-query@v1
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -114,7 +114,7 @@ jobs:
 
       - name: Notify CI about completion of the workflow
         if: github.event_name == 'workflow_dispatch'
-        uses: keep-network/ci/actions/notify-workflow-completed@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/notify-workflow-completed@v1
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
We've moved custom actions used in the Keep/tBTC Continuous Integration
from separate repositories to `ci` repository (under `actions` folder).
We now need to update all the actions' invokations.

Note that temporarily we call the actions on the feature branch - this
is only for testing purposes and will be changed to `@v1` once tested.

Refs:
https://github.com/keep-network/ci/pull/11
https://github.com/keep-network/keep-core/pull/2545
https://github.com/keep-network/keep-ecdsa/pull/868
https://github.com/keep-network/tbtc/pull/816
https://github.com/keep-network/tbtc.js/pull/128
https://github.com/keep-network/coverage-pools/pull/167

TODO:
- [x] test deployment flow on the feature branch
- [x] point to `@v1` in lines invoking actions (same change required in other repos)