### PR TITLE
Publish tBTC dApp to GCS bucket 

### DIFF
--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -79,38 +79,23 @@ jobs:
             npm install --save-exact \
               @keep-network/tbtc.js@${{ steps.upstream-builds-query.outputs.tbtcjs-version }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+      - name: NPM install
+        run: npm ci
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+      - name: NPM build
+        run: npm run build
 
-      - name: Login to Google Container Registry
+      - name: Deploy to GCP bucket
         if: github.event_name == 'workflow_dispatch'
-        uses: docker/login-action@v1
+        uses: thesis/gcp-storage-bucket-action@v3.1.0
         with:
-          registry: ${{ env.GCR_REGISTRY_URL }}
-          username: _json_key
-          password: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
-
-      - name: Build and publish Keep Token Dashboard image
-        uses: docker/build-push-action@v2
-        env:
-          IMAGE_NAME: 'tbtc-dapp'
-        with:
-          # GCR image should be named according to following convention:
-          # HOSTNAME/PROJECT-ID/IMAGE:TAG
-          # We don't use TAG yet, will be added at later stages of work on RFC-18.
-          tags: ${{ env.GCR_REGISTRY_URL }}/${{ env.GOOGLE_PROJECT_ID }}/${{ env.IMAGE_NAME }}
-          labels: revision=${{ github.sha }}
-          push: ${{ github.event_name == 'workflow_dispatch' }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          service-key: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
+          project: ${{ env.GOOGLE_PROJECT_ID }}
+          bucket-name: keep-test-tbtc-dapp # TODO: Change to dapp.test.tbtc.network
+          set-website: true
+          home-page-path: index.html
+          error-page-path: index.html
+          build-folder: build
 
       - name: Notify CI about completion of the workflow
         if: github.event_name == 'workflow_dispatch'
@@ -124,16 +109,6 @@ jobs:
           upstream_builds: ${{ github.event.inputs.upstream_builds }}
           upstream_ref: ${{ github.event.inputs.upstream_ref }}
           version: ${{ github.sha }}
-
-      - # Temp fix - move cache instead of copying (added below step and
-        # modified value of `cache-to`).
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        # Without the change some jobs were failing with `no space left on device`
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   dapp-lint:
     needs: dapp-detect-changes

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           service-key: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
           project: ${{ env.GOOGLE_PROJECT_ID }}
-          bucket-name: keep-test-tbtc-dapp # TODO: Change to dapp.test.tbtc.network
+          bucket-name: dapp.test.tbtc.network
           set-website: true
           home-page-path: index.html
           error-page-path: index.html

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -79,9 +79,6 @@ jobs:
             npm install --save-exact \
               @keep-network/tbtc.js@${{ steps.upstream-builds-query.outputs.tbtcjs-version }}
 
-      - name: NPM install
-        run: npm ci
-
       - name: NPM build
         run: npm run build
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -22,7 +22,7 @@ function App(props) {
             <a
               href="https://chat.tbtc.network/"
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
             >
               visit our Discord community ↗
             </a>

--- a/src/components/redemption/Start.js
+++ b/src/components/redemption/Start.js
@@ -41,7 +41,7 @@ const Start = ({ saveAddresses, resetState, openWalletModal }) => {
       const hasError = !isValid
       setDepositAddress({ address: depositAddress.address, isValid, hasError })
     }
-  }, [])
+  }, [depositAddress.address])
 
   const { active } = useWeb3React()
 


### PR DESCRIPTION
Here we change the tBTC dApp job to publish static files to the GCS bucket instead of building and pushing a Docker image. This change is a part of our shift from Kubernetes to GCS as a hosting platform for static websites/dapps.

Tagging @r-czajkowski to take a look at React changes (https://github.com/keep-network/tbtc-dapp/pull/403/commits/70638e77c46123e377cfff0a45f05db91bc0f776) needed to make the build passing.