### PR TITLE
Adding cron for daily tests and builds on Meercode

### DIFF
--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -1,6 +1,8 @@
 name: Dapp
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
The purpose of this PR is to set a cron job that would run tests and builds on a daily basis (at midnight) so the results can be displayed on Meercode dashboard.