### PR TITLE
Bump-up version of tbtc.js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1462,16 +1462,16 @@
             }
         },
         "@celo/base": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@celo/base/-/base-1.1.0.tgz",
-            "integrity": "sha512-CKWx0UyeYTGIQLPzcopA6Y0CDcapga0fTHod3ZVYjVlH/HsVQlm2MjSQp8iTMeLu91mPYDo581HcATlCkZ58Rg=="
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@celo/base/-/base-1.5.1.tgz",
+            "integrity": "sha512-76MAosahwCDjkBsqfgnKT2CbyjV6TdzIztHJvAuJ+VrKeaIFe/IMoPwIxPy95xDJmHhD0zqPWMixGeyVGAwYQw=="
         },
         "@celo/connect": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@celo/connect/-/connect-1.1.0.tgz",
-            "integrity": "sha512-XUIKhI6BeYYD6ZA5P09ZspuUdYIa+Cg2rGavrGaWXa03SHXpJVy9iG/NhcGC9VpNrDCeW4TdNFhEveXnnDWsrg==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@celo/connect/-/connect-1.5.1.tgz",
+            "integrity": "sha512-UjZIu1GRvnsUrGfTUDqxyrt8qyDpj4cuxQ/WVETss8l+x98zV5/7edKOA0QRWEKFhh3F1mCi0N08hEpp+q7QaA==",
             "requires": {
-                "@celo/utils": "1.1.0",
+                "@celo/utils": "1.5.1",
                 "@types/debug": "^4.1.5",
                 "@types/utf8": "^2.1.6",
                 "bignumber.js": "^9.0.0",
@@ -1480,9 +1480,9 @@
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.3.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
                     "requires": {
                         "ms": "2.1.2"
                     }
@@ -1495,152 +1495,41 @@
             }
         },
         "@celo/contractkit": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@celo/contractkit/-/contractkit-1.1.0.tgz",
-            "integrity": "sha512-PgAMR71A08cZGhOICtrNj8EfYMon7PWNMQD+52X38CvfVJkg+/d56vfgbhBTHluQEhRTA/F0Y9MG3qgSUAzvDg==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@celo/contractkit/-/contractkit-1.5.1.tgz",
+            "integrity": "sha512-hUgH0yTbI1JUn9ytCWW/0QLfAruF3YL5xfcSmzXItklQ2GKGsTSfGlY7XTUY97xq/WYO2InXw+Vuhop6CcFOiw==",
             "requires": {
-                "@celo/base": "1.1.0",
-                "@celo/connect": "1.1.0",
-                "@celo/utils": "1.1.0",
-                "@celo/wallet-local": "1.1.0",
+                "@celo/base": "1.5.1",
+                "@celo/connect": "1.5.1",
+                "@celo/utils": "1.5.1",
+                "@celo/wallet-local": "1.5.1",
                 "@types/debug": "^4.1.5",
                 "bignumber.js": "^9.0.0",
-                "cross-fetch": "3.0.4",
+                "cross-fetch": "^3.0.6",
                 "debug": "^4.1.1",
                 "fp-ts": "2.1.1",
                 "io-ts": "2.0.1",
-                "moment": "^2.29.0",
-                "web3": "1.3.4"
+                "semver": "^7.3.5",
+                "web3": "1.3.6"
             },
             "dependencies": {
-                "@ethersproject/abi": {
-                    "version": "5.0.7",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.7.tgz",
-                    "integrity": "sha512-Cqktk+hSIckwP/W8O47Eef60VwmoSC/L3lY0+dIBhQPCNn9E4V7rwmm2aFrNRRDJfFlGuZ1khkQUOc3oBX+niw==",
-                    "requires": {
-                        "@ethersproject/address": "^5.0.4",
-                        "@ethersproject/bignumber": "^5.0.7",
-                        "@ethersproject/bytes": "^5.0.4",
-                        "@ethersproject/constants": "^5.0.4",
-                        "@ethersproject/hash": "^5.0.4",
-                        "@ethersproject/keccak256": "^5.0.3",
-                        "@ethersproject/logger": "^5.0.5",
-                        "@ethersproject/properties": "^5.0.3",
-                        "@ethersproject/strings": "^5.0.4"
-                    }
-                },
-                "@ethersproject/address": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.1.0.tgz",
-                    "integrity": "sha512-rfWQR12eHn2cpstCFS4RF7oGjfbkZb0oqep+BfrT+gWEGWG2IowJvIsacPOvzyS1jhNF4MQ4BS59B04Mbovteg==",
-                    "requires": {
-                        "@ethersproject/bignumber": "^5.1.0",
-                        "@ethersproject/bytes": "^5.1.0",
-                        "@ethersproject/keccak256": "^5.1.0",
-                        "@ethersproject/logger": "^5.1.0",
-                        "@ethersproject/rlp": "^5.1.0"
-                    }
-                },
-                "@ethersproject/bignumber": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.1.0.tgz",
-                    "integrity": "sha512-wUvQlhTjPjFXIdLPOuTrFeQmSa6Wvls1bGXQNQWvB/SEn1NsTCE8PmumIEZxmOPjSHl1eV2uyHP5jBm5Cgj92Q==",
-                    "requires": {
-                        "@ethersproject/bytes": "^5.1.0",
-                        "@ethersproject/logger": "^5.1.0",
-                        "bn.js": "^4.4.0"
-                    }
-                },
-                "@ethersproject/bytes": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.1.0.tgz",
-                    "integrity": "sha512-sGTxb+LVjFxJcJeUswAIK6ncgOrh3D8c192iEJd7mLr95V6du119rRfYT/b87WPkZ5I3gRBUYIYXtdgCWACe8g==",
-                    "requires": {
-                        "@ethersproject/logger": "^5.1.0"
-                    }
-                },
-                "@ethersproject/constants": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.1.0.tgz",
-                    "integrity": "sha512-0/SuHrxc8R8k+JiLmJymxHJbojUDWBQqO+b+XFdwaP0jGzqC09YDy/CAlSZB6qHsBifY8X3I89HcK/oMqxRdBw==",
-                    "requires": {
-                        "@ethersproject/bignumber": "^5.1.0"
-                    }
-                },
-                "@ethersproject/hash": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.1.0.tgz",
-                    "integrity": "sha512-fNwry20yLLPpnRRwm3fBL+2ksgO+KMadxM44WJmRIoTKzy4269+rbq9KFoe2LTqq2CXJM2CE70beGaNrpuqflQ==",
-                    "requires": {
-                        "@ethersproject/abstract-signer": "^5.1.0",
-                        "@ethersproject/address": "^5.1.0",
-                        "@ethersproject/bignumber": "^5.1.0",
-                        "@ethersproject/bytes": "^5.1.0",
-                        "@ethersproject/keccak256": "^5.1.0",
-                        "@ethersproject/logger": "^5.1.0",
-                        "@ethersproject/properties": "^5.1.0",
-                        "@ethersproject/strings": "^5.1.0"
-                    }
-                },
-                "@ethersproject/keccak256": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.1.0.tgz",
-                    "integrity": "sha512-vrTB1W6AEYoadww5c9UyVJ2YcSiyIUTNDRccZIgwTmFFoSHwBtcvG1hqy9RzJ1T0bMdATbM9Hfx2mJ6H0i7Hig==",
-                    "requires": {
-                        "@ethersproject/bytes": "^5.1.0",
-                        "js-sha3": "0.5.7"
-                    }
-                },
-                "@ethersproject/logger": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.1.0.tgz",
-                    "integrity": "sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw=="
-                },
-                "@ethersproject/properties": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.1.0.tgz",
-                    "integrity": "sha512-519KKTwgmH42AQL3+GFV3SX6khYEfHsvI6v8HYejlkigSDuqttdgVygFTDsGlofNFchhDwuclrxQnD5B0YLNMg==",
-                    "requires": {
-                        "@ethersproject/logger": "^5.1.0"
-                    }
-                },
-                "@ethersproject/rlp": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.1.0.tgz",
-                    "integrity": "sha512-vDTyHIwNPrecy55gKGZ47eJZhBm8LLBxihzi5ou+zrSvYTpkSTWRcKUlXFDFQVwfWB+P5PGyERAdiDEI76clxw==",
-                    "requires": {
-                        "@ethersproject/bytes": "^5.1.0",
-                        "@ethersproject/logger": "^5.1.0"
-                    }
-                },
-                "@ethersproject/strings": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.1.0.tgz",
-                    "integrity": "sha512-perBZy0RrmmL0ejiFGUOlBVjMsUceqLut3OBP3zP96LhiJWWbS8u1NqQVgN4/Gyrbziuda66DxiQocXhsvx+Sw==",
-                    "requires": {
-                        "@ethersproject/bytes": "^5.1.0",
-                        "@ethersproject/constants": "^5.1.0",
-                        "@ethersproject/logger": "^5.1.0"
-                    }
-                },
                 "@types/node": {
-                    "version": "12.20.7",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-                    "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+                    "version": "12.20.41",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
+                    "integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
                 },
                 "cross-fetch": {
-                    "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
-                    "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
+                    "version": "3.1.4",
+                    "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+                    "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
                     "requires": {
-                        "node-fetch": "2.6.0",
-                        "whatwg-fetch": "3.0.0"
+                        "node-fetch": "2.6.1"
                     }
                 },
                 "debug": {
-                    "version": "4.3.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
                     "requires": {
                         "ms": "2.1.2"
                     }
@@ -1663,10 +1552,13 @@
                     "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
                     "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
                 },
-                "js-sha3": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-                    "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
                 },
                 "mimic-response": {
                     "version": "1.0.1",
@@ -1679,9 +1571,9 @@
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 },
                 "node-fetch": {
-                    "version": "2.6.0",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-                    "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+                    "version": "2.6.1",
+                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+                    "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
                 },
                 "oboe": {
                     "version": "2.1.5",
@@ -1700,6 +1592,14 @@
                     "version": "1.0.4",
                     "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
                     "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+                },
+                "semver": {
+                    "version": "7.3.5",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
                 },
                 "swarm-js": {
                     "version": "0.1.40",
@@ -1742,6 +1642,11 @@
                         }
                     }
                 },
+                "underscore": {
+                    "version": "1.12.1",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+                    "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+                },
                 "url-parse-lax": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -1751,9 +1656,9 @@
                     }
                 },
                 "util": {
-                    "version": "0.12.3",
-                    "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
-                    "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+                    "version": "0.12.4",
+                    "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+                    "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
                     "requires": {
                         "inherits": "^2.0.3",
                         "is-arguments": "^1.0.4",
@@ -1769,144 +1674,144 @@
                     "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
                 },
                 "web3": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.4.tgz",
-                    "integrity": "sha512-D6cMb2EtTMLHgdGbkTPGl/Qi7DAfczR+Lp7iFX3bcu/bsD9V8fZW69hA8v5cRPNGzXUwVQebk3bS17WKR4cD2w==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.6.tgz",
+                    "integrity": "sha512-jEpPhnL6GDteifdVh7ulzlPrtVQeA30V9vnki9liYlUvLV82ZM7BNOQJiuzlDePuE+jZETZSP/0G/JlUVt6pOA==",
                     "requires": {
-                        "web3-bzz": "1.3.4",
-                        "web3-core": "1.3.4",
-                        "web3-eth": "1.3.4",
-                        "web3-eth-personal": "1.3.4",
-                        "web3-net": "1.3.4",
-                        "web3-shh": "1.3.4",
-                        "web3-utils": "1.3.4"
+                        "web3-bzz": "1.3.6",
+                        "web3-core": "1.3.6",
+                        "web3-eth": "1.3.6",
+                        "web3-eth-personal": "1.3.6",
+                        "web3-net": "1.3.6",
+                        "web3-shh": "1.3.6",
+                        "web3-utils": "1.3.6"
                     }
                 },
                 "web3-bzz": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.4.tgz",
-                    "integrity": "sha512-DBRVQB8FAgoAtZCpp2GAGPCJjgBgsuwOKEasjV044AAZiONpXcKHbkO6G1SgItIixnrJsRJpoGLGw52Byr6FKw==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.6.tgz",
+                    "integrity": "sha512-ibHdx1wkseujFejrtY7ZyC0QxQ4ATXjzcNUpaLrvM6AEae8prUiyT/OloG9FWDgFD2CPLwzKwfSQezYQlANNlw==",
                     "requires": {
                         "@types/node": "^12.12.6",
                         "got": "9.6.0",
                         "swarm-js": "^0.1.40",
-                        "underscore": "1.9.1"
+                        "underscore": "1.12.1"
                     }
                 },
                 "web3-core": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.4.tgz",
-                    "integrity": "sha512-7OJu46RpCEfTerl+gPvHXANR2RkLqAfW7l2DAvQ7wN0pnCzl9nEfdgW6tMhr31k3TR2fWucwKzCyyxMGzMHeSA==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.6.tgz",
+                    "integrity": "sha512-gkLDM4T1Sc0T+HZIwxrNrwPg0IfWI0oABSglP2X5ZbBAYVUeEATA0o92LWV8BeF+okvKXLK1Fek/p6axwM/h3Q==",
                     "requires": {
                         "@types/bn.js": "^4.11.5",
                         "@types/node": "^12.12.6",
                         "bignumber.js": "^9.0.0",
-                        "web3-core-helpers": "1.3.4",
-                        "web3-core-method": "1.3.4",
-                        "web3-core-requestmanager": "1.3.4",
-                        "web3-utils": "1.3.4"
+                        "web3-core-helpers": "1.3.6",
+                        "web3-core-method": "1.3.6",
+                        "web3-core-requestmanager": "1.3.6",
+                        "web3-utils": "1.3.6"
                     }
                 },
                 "web3-core-helpers": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.4.tgz",
-                    "integrity": "sha512-n7BqDalcTa1stncHMmrnFtyTgDhX5Fy+avNaHCf6qcOP2lwTQC8+mdHVBONWRJ6Yddvln+c8oY/TAaB6PzWK0A==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.6.tgz",
+                    "integrity": "sha512-nhtjA2ZbkppjlxTSwG0Ttu6FcPkVu1rCN5IFAOVpF/L0SEt+jy+O5l90+cjDq0jAYvlBwUwnbh2mR9hwDEJCNA==",
                     "requires": {
-                        "underscore": "1.9.1",
-                        "web3-eth-iban": "1.3.4",
-                        "web3-utils": "1.3.4"
+                        "underscore": "1.12.1",
+                        "web3-eth-iban": "1.3.6",
+                        "web3-utils": "1.3.6"
                     }
                 },
                 "web3-core-method": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.4.tgz",
-                    "integrity": "sha512-JxmQrujsAWYRRN77P/RY7XuZDCzxSiiQJrgX/60Lfyf7FF1Y0le4L/UMCi7vUJnuYkbU1Kfl9E0udnqwyPqlvQ==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.6.tgz",
+                    "integrity": "sha512-RyegqVGxn0cyYW5yzAwkPlsSEynkdPiegd7RxgB4ak1eKk2Cv1q2x4C7D2sZjeeCEF+q6fOkVmo2OZNqS2iQxg==",
                     "requires": {
                         "@ethersproject/transactions": "^5.0.0-beta.135",
-                        "underscore": "1.9.1",
-                        "web3-core-helpers": "1.3.4",
-                        "web3-core-promievent": "1.3.4",
-                        "web3-core-subscriptions": "1.3.4",
-                        "web3-utils": "1.3.4"
+                        "underscore": "1.12.1",
+                        "web3-core-helpers": "1.3.6",
+                        "web3-core-promievent": "1.3.6",
+                        "web3-core-subscriptions": "1.3.6",
+                        "web3-utils": "1.3.6"
                     }
                 },
                 "web3-core-promievent": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.4.tgz",
-                    "integrity": "sha512-V61dZIeBwogg6hhZZUt0qL9hTp1WDhnsdjP++9fhTDr4vy/Gz8T5vibqT2LLg6lQC8i+Py33yOpMeMNjztaUaw==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.6.tgz",
+                    "integrity": "sha512-Z+QzfyYDTXD5wJmZO5wwnRO8bAAHEItT1XNSPVb4J1CToV/I/SbF7CuF8Uzh2jns0Cm1109o666H7StFFvzVKw==",
                     "requires": {
                         "eventemitter3": "4.0.4"
                     }
                 },
                 "web3-core-requestmanager": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.4.tgz",
-                    "integrity": "sha512-xriouCrhVnVDYQ04TZXdEREZm0OOJzkSEsoN5bu4JYsA6e/HzROeU+RjDpMUxFMzN4wxmFZ+HWbpPndS3QwMag==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.6.tgz",
+                    "integrity": "sha512-2rIaeuqeo7QN1Eex7aXP0ZqeteJEPWXYFS/M3r3LXMiV8R4STQBKE+//dnHJXoo2ctzEB5cgd+7NaJM8S3gPyA==",
                     "requires": {
-                        "underscore": "1.9.1",
+                        "underscore": "1.12.1",
                         "util": "^0.12.0",
-                        "web3-core-helpers": "1.3.4",
-                        "web3-providers-http": "1.3.4",
-                        "web3-providers-ipc": "1.3.4",
-                        "web3-providers-ws": "1.3.4"
+                        "web3-core-helpers": "1.3.6",
+                        "web3-providers-http": "1.3.6",
+                        "web3-providers-ipc": "1.3.6",
+                        "web3-providers-ws": "1.3.6"
                     }
                 },
                 "web3-core-subscriptions": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.4.tgz",
-                    "integrity": "sha512-drVHVDxh54hv7xmjIm44g4IXjfGj022fGw4/meB5R2D8UATFI40F73CdiBlyqk3DysP9njDOLTJFSQvEkLFUOg==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.6.tgz",
+                    "integrity": "sha512-wi9Z9X5X75OKvxAg42GGIf81ttbNR2TxzkAsp1g+nnp5K8mBwgZvXrIsDuj7Z7gx72Y45mWJADCWjk/2vqNu8g==",
                     "requires": {
                         "eventemitter3": "4.0.4",
-                        "underscore": "1.9.1",
-                        "web3-core-helpers": "1.3.4"
+                        "underscore": "1.12.1",
+                        "web3-core-helpers": "1.3.6"
                     }
                 },
                 "web3-eth": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.4.tgz",
-                    "integrity": "sha512-8OIVMLbvmx+LB5RZ4tDhXuFGWSdNMrCZ4HM0+PywQ08uEcmAcqTMFAn4vdPii+J8gCatZR501r1KdzX3SDLoPw==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.6.tgz",
+                    "integrity": "sha512-9+rnywRRpyX3C4hfsAQXPQh6vHh9XzQkgLxo3gyeXfbhbShUoq2gFVuy42vsRs//6JlsKdyZS7Z3hHPHz2wreA==",
                     "requires": {
-                        "underscore": "1.9.1",
-                        "web3-core": "1.3.4",
-                        "web3-core-helpers": "1.3.4",
-                        "web3-core-method": "1.3.4",
-                        "web3-core-subscriptions": "1.3.4",
-                        "web3-eth-abi": "1.3.4",
-                        "web3-eth-accounts": "1.3.4",
-                        "web3-eth-contract": "1.3.4",
-                        "web3-eth-ens": "1.3.4",
-                        "web3-eth-iban": "1.3.4",
-                        "web3-eth-personal": "1.3.4",
-                        "web3-net": "1.3.4",
-                        "web3-utils": "1.3.4"
+                        "underscore": "1.12.1",
+                        "web3-core": "1.3.6",
+                        "web3-core-helpers": "1.3.6",
+                        "web3-core-method": "1.3.6",
+                        "web3-core-subscriptions": "1.3.6",
+                        "web3-eth-abi": "1.3.6",
+                        "web3-eth-accounts": "1.3.6",
+                        "web3-eth-contract": "1.3.6",
+                        "web3-eth-ens": "1.3.6",
+                        "web3-eth-iban": "1.3.6",
+                        "web3-eth-personal": "1.3.6",
+                        "web3-net": "1.3.6",
+                        "web3-utils": "1.3.6"
                     }
                 },
                 "web3-eth-abi": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.4.tgz",
-                    "integrity": "sha512-PVSLXJ2dzdXsC+R24llIIEOS6S1KhG5qwNznJjJvXZFe3sqgdSe47eNvwUamZtCBjcrdR/HQr+L/FTxqJSf80Q==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.6.tgz",
+                    "integrity": "sha512-Or5cRnZu6WzgScpmbkvC6bfNxR26hqiKK4i8sMPFeTUABQcb/FU3pBj7huBLYbp9dH+P5W79D2MqwbWwjj9DoQ==",
                     "requires": {
                         "@ethersproject/abi": "5.0.7",
-                        "underscore": "1.9.1",
-                        "web3-utils": "1.3.4"
+                        "underscore": "1.12.1",
+                        "web3-utils": "1.3.6"
                     }
                 },
                 "web3-eth-accounts": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.4.tgz",
-                    "integrity": "sha512-gz9ReSmQEjqbYAjpmAx+UZF4CVMbyS4pfjSYWGAnNNI+Xz0f0u0kCIYXQ1UEaE+YeLcYiE+ZlZdgg6YoatO5nA==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.6.tgz",
+                    "integrity": "sha512-Ilr0hG6ONbCdSlVKffasCmNwftD5HsNpwyQASevocIQwHdTlvlwO0tb3oGYuajbKOaDzNTwXfz25bttAEoFCGA==",
                     "requires": {
                         "crypto-browserify": "3.12.0",
                         "eth-lib": "0.2.8",
                         "ethereumjs-common": "^1.3.2",
                         "ethereumjs-tx": "^2.1.1",
                         "scrypt-js": "^3.0.1",
-                        "underscore": "1.9.1",
+                        "underscore": "1.12.1",
                         "uuid": "3.3.2",
-                        "web3-core": "1.3.4",
-                        "web3-core-helpers": "1.3.4",
-                        "web3-core-method": "1.3.4",
-                        "web3-utils": "1.3.4"
+                        "web3-core": "1.3.6",
+                        "web3-core-helpers": "1.3.6",
+                        "web3-core-method": "1.3.6",
+                        "web3-utils": "1.3.6"
                     },
                     "dependencies": {
                         "eth-lib": {
@@ -1922,114 +1827,114 @@
                     }
                 },
                 "web3-eth-contract": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.4.tgz",
-                    "integrity": "sha512-Fvy8ZxUksQY2ePt+XynFfOiSqxgQtMn4m2NJs6VXRl2Inl17qyRi/nIJJVKTcENLocm+GmZ/mxq2eOE5u02nPg==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.6.tgz",
+                    "integrity": "sha512-8gDaRrLF2HCg+YEZN1ov0zN35vmtPnGf3h1DxmJQK5Wm2lRMLomz9rsWsuvig3UJMHqZAQKD7tOl3ocJocQsmA==",
                     "requires": {
                         "@types/bn.js": "^4.11.5",
-                        "underscore": "1.9.1",
-                        "web3-core": "1.3.4",
-                        "web3-core-helpers": "1.3.4",
-                        "web3-core-method": "1.3.4",
-                        "web3-core-promievent": "1.3.4",
-                        "web3-core-subscriptions": "1.3.4",
-                        "web3-eth-abi": "1.3.4",
-                        "web3-utils": "1.3.4"
+                        "underscore": "1.12.1",
+                        "web3-core": "1.3.6",
+                        "web3-core-helpers": "1.3.6",
+                        "web3-core-method": "1.3.6",
+                        "web3-core-promievent": "1.3.6",
+                        "web3-core-subscriptions": "1.3.6",
+                        "web3-eth-abi": "1.3.6",
+                        "web3-utils": "1.3.6"
                     }
                 },
                 "web3-eth-ens": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.4.tgz",
-                    "integrity": "sha512-b0580tQyQwpV2wyacwQiBEfQmjCUln5iPhge3IBIMXaI43BUNtH3lsCL9ERFQeOdweB4o+6rYyNYr6xbRcSytg==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.6.tgz",
+                    "integrity": "sha512-n27HNj7lpSkRxTgSx+Zo7cmKAgyg2ElFilaFlUu/X2CNH23lXfcPm2bWssivH9z0ndhg0OyR4AYFZqPaqDHkJA==",
                     "requires": {
                         "content-hash": "^2.5.2",
                         "eth-ens-namehash": "2.0.8",
-                        "underscore": "1.9.1",
-                        "web3-core": "1.3.4",
-                        "web3-core-helpers": "1.3.4",
-                        "web3-core-promievent": "1.3.4",
-                        "web3-eth-abi": "1.3.4",
-                        "web3-eth-contract": "1.3.4",
-                        "web3-utils": "1.3.4"
+                        "underscore": "1.12.1",
+                        "web3-core": "1.3.6",
+                        "web3-core-helpers": "1.3.6",
+                        "web3-core-promievent": "1.3.6",
+                        "web3-eth-abi": "1.3.6",
+                        "web3-eth-contract": "1.3.6",
+                        "web3-utils": "1.3.6"
                     }
                 },
                 "web3-eth-iban": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.4.tgz",
-                    "integrity": "sha512-Y7/hLjVvIN/OhaAyZ8L/hxbTqVX6AFTl2RwUXR6EEU9oaLydPcMjAx/Fr8mghUvQS3QJSr+UGubP3W4SkyNiYw==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.6.tgz",
+                    "integrity": "sha512-nfMQaaLA/zsg5W4Oy/EJQbs8rSs1vBAX6b/35xzjYoutXlpHMQadujDx2RerTKhSHqFXSJeQAfE+2f6mdhYkRQ==",
                     "requires": {
                         "bn.js": "^4.11.9",
-                        "web3-utils": "1.3.4"
+                        "web3-utils": "1.3.6"
                     }
                 },
                 "web3-eth-personal": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.4.tgz",
-                    "integrity": "sha512-JiTbaktYVk1j+S2EDooXAhw5j/VsdvZfKRmHtXUe/HizPM9ETXmj1+ne4RT6m+950jQ7DJwUF3XU1FKYNtEDwQ==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.6.tgz",
+                    "integrity": "sha512-pOHU0+/h1RFRYoh1ehYBehRbcKWP4OSzd4F7mDljhHngv6W8ewMHrAN8O1ol9uysN2MuCdRE19qkRg5eNgvzFQ==",
                     "requires": {
                         "@types/node": "^12.12.6",
-                        "web3-core": "1.3.4",
-                        "web3-core-helpers": "1.3.4",
-                        "web3-core-method": "1.3.4",
-                        "web3-net": "1.3.4",
-                        "web3-utils": "1.3.4"
+                        "web3-core": "1.3.6",
+                        "web3-core-helpers": "1.3.6",
+                        "web3-core-method": "1.3.6",
+                        "web3-net": "1.3.6",
+                        "web3-utils": "1.3.6"
                     }
                 },
                 "web3-net": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.4.tgz",
-                    "integrity": "sha512-wVyqgVC3Zt/0uGnBiR3GpnsS8lvOFTDgWZMxAk9C6Guh8aJD9MUc7pbsw5rHrPUVe6S6RUfFJvh/Xq8oMIQgSw==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.6.tgz",
+                    "integrity": "sha512-KhzU3wMQY/YYjyMiQzbaLPt2kut88Ncx2iqjy3nw28vRux3gVX0WOCk9EL/KVJBiAA/fK7VklTXvgy9dZnnipw==",
                     "requires": {
-                        "web3-core": "1.3.4",
-                        "web3-core-method": "1.3.4",
-                        "web3-utils": "1.3.4"
+                        "web3-core": "1.3.6",
+                        "web3-core-method": "1.3.6",
+                        "web3-utils": "1.3.6"
                     }
                 },
                 "web3-providers-http": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.4.tgz",
-                    "integrity": "sha512-aIg/xHXvxpqpFU70sqfp+JC3sGkLfAimRKTUhG4oJZ7U+tTcYTHoxBJj+4A3Id4JAoKiiv0k1/qeyQ8f3rMC3g==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.6.tgz",
+                    "integrity": "sha512-OQkT32O1A06dISIdazpGLveZcOXhEo5cEX6QyiSQkiPk/cjzDrXMw4SKZOGQbbS1+0Vjizm1Hrp7O8Vp2D1M5Q==",
                     "requires": {
-                        "web3-core-helpers": "1.3.4",
+                        "web3-core-helpers": "1.3.6",
                         "xhr2-cookies": "1.1.0"
                     }
                 },
                 "web3-providers-ipc": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.4.tgz",
-                    "integrity": "sha512-E0CvXEJElr/TIlG1YfJeO3Le5NI/4JZM+1SsEdiPIfBUAJN18oOoum138EBGKv5+YaLKZUtUuJSXWjIIOR/0Ig==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.6.tgz",
+                    "integrity": "sha512-+TVsSd2sSVvVgHG4s6FXwwYPPT91boKKcRuEFXqEfAbUC5t52XOgmyc2LNiD9LzPhed65FbV4LqICpeYGUvSwA==",
                     "requires": {
                         "oboe": "2.1.5",
-                        "underscore": "1.9.1",
-                        "web3-core-helpers": "1.3.4"
+                        "underscore": "1.12.1",
+                        "web3-core-helpers": "1.3.6"
                     }
                 },
                 "web3-providers-ws": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.4.tgz",
-                    "integrity": "sha512-WBd9hk2fUAdrbA3kUyUk94ZeILtE6txLeoVVvIKAw2bPegx+RjkLyxC1Du0oceKgQ/qQWod8CCzl1E/GgTP+MQ==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.6.tgz",
+                    "integrity": "sha512-bk7MnJf5or0Re2zKyhR3L3CjGululLCHXx4vlbc/drnaTARUVvi559OI5uLytc/1k5HKUUyENAxLvetz2G1dnQ==",
                     "requires": {
                         "eventemitter3": "4.0.4",
-                        "underscore": "1.9.1",
-                        "web3-core-helpers": "1.3.4",
+                        "underscore": "1.12.1",
+                        "web3-core-helpers": "1.3.6",
                         "websocket": "^1.0.32"
                     }
                 },
                 "web3-shh": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.4.tgz",
-                    "integrity": "sha512-zoeww5mxLh3xKcqbX85irQbtFe5pc5XwrgjvmdMkhkOdZzPASlWOgqzUFtaPykpLwC3yavVx4jG5RqifweXLUA==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.6.tgz",
+                    "integrity": "sha512-9zRo415O0iBslxBnmu9OzYjNErzLnzOsy+IOvSpIreLYbbAw0XkDWxv3SfcpKnTIWIACBR4AYMIxmmyi5iB3jw==",
                     "requires": {
-                        "web3-core": "1.3.4",
-                        "web3-core-method": "1.3.4",
-                        "web3-core-subscriptions": "1.3.4",
-                        "web3-net": "1.3.4"
+                        "web3-core": "1.3.6",
+                        "web3-core-method": "1.3.6",
+                        "web3-core-subscriptions": "1.3.6",
+                        "web3-net": "1.3.6"
                     }
                 },
                 "web3-utils": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.4.tgz",
-                    "integrity": "sha512-/vC2v0MaZNpWooJfpRw63u0Y3ag2gNjAWiLtMSL6QQLmCqCy4SQIndMt/vRyx0uMoeGt1YTwSXEcHjUzOhLg0A==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.6.tgz",
+                    "integrity": "sha512-hHatFaQpkQgjGVER17gNx8u1qMyaXFZtM0y0XLGH1bzsjMPlkMPLRcYOrZ00rOPfTEuYFOdrpGOqZXVmGrMZRg==",
                     "requires": {
                         "bn.js": "^4.11.9",
                         "eth-lib": "0.2.8",
@@ -2037,7 +1942,7 @@
                         "ethjs-unit": "0.1.6",
                         "number-to-bn": "1.7.0",
                         "randombytes": "^2.1.0",
-                        "underscore": "1.9.1",
+                        "underscore": "1.12.1",
                         "utf8": "3.0.0"
                     },
                     "dependencies": {
@@ -2054,9 +1959,9 @@
                     }
                 },
                 "websocket": {
-                    "version": "1.0.33",
-                    "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.33.tgz",
-                    "integrity": "sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==",
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
+                    "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
                     "requires": {
                         "bufferutil": "^4.0.1",
                         "debug": "^2.2.0",
@@ -2081,27 +1986,26 @@
                         }
                     }
                 },
-                "whatwg-fetch": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-                    "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
                 }
             }
         },
         "@celo/utils": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@celo/utils/-/utils-1.1.0.tgz",
-            "integrity": "sha512-FulCMswjXZZjylBV/veKQ8ESCPdfF2CBitPQL6EWinIv8UIJysQJkINjKDNBzegeHd/hDL6acXXFDv2ehmNynQ==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@celo/utils/-/utils-1.5.1.tgz",
+            "integrity": "sha512-3ZqZ/YSvzcESd72+8oNOvIM5HieJt3zusRCBPIl97qnqlnCIIq22gxcvpKL1afac0q79t24jkbdl5wsAkD/ROA==",
             "requires": {
-                "@celo/base": "1.1.0",
+                "@celo/base": "1.5.1",
                 "@types/country-data": "^0.0.0",
                 "@types/elliptic": "^6.4.9",
                 "@types/ethereumjs-util": "^5.2.0",
                 "@types/google-libphonenumber": "^7.4.17",
-                "@types/lodash": "^4.14.136",
+                "@types/lodash": "^4.14.170",
                 "@types/node": "^10.12.18",
                 "@types/randombytes": "^2.0.0",
-                "@umpirsky/country-list": "git+https://github.com/umpirsky/country-list.git#05fda51",
                 "bigi": "^1.1.0",
                 "bignumber.js": "^9.0.0",
                 "bip32": "2.0.5",
@@ -2117,126 +2021,16 @@
                 "google-libphonenumber": "^3.2.15",
                 "io-ts": "2.0.1",
                 "keccak256": "^1.0.0",
-                "lodash": "^4.17.14",
+                "lodash": "^4.17.21",
                 "numeral": "^2.0.6",
-                "web3-eth-abi": "1.3.4",
-                "web3-utils": "1.3.4"
+                "web3-eth-abi": "1.3.6",
+                "web3-utils": "1.3.6"
             },
             "dependencies": {
-                "@ethersproject/abi": {
-                    "version": "5.0.7",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.7.tgz",
-                    "integrity": "sha512-Cqktk+hSIckwP/W8O47Eef60VwmoSC/L3lY0+dIBhQPCNn9E4V7rwmm2aFrNRRDJfFlGuZ1khkQUOc3oBX+niw==",
-                    "requires": {
-                        "@ethersproject/address": "^5.0.4",
-                        "@ethersproject/bignumber": "^5.0.7",
-                        "@ethersproject/bytes": "^5.0.4",
-                        "@ethersproject/constants": "^5.0.4",
-                        "@ethersproject/hash": "^5.0.4",
-                        "@ethersproject/keccak256": "^5.0.3",
-                        "@ethersproject/logger": "^5.0.5",
-                        "@ethersproject/properties": "^5.0.3",
-                        "@ethersproject/strings": "^5.0.4"
-                    }
-                },
-                "@ethersproject/address": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.1.0.tgz",
-                    "integrity": "sha512-rfWQR12eHn2cpstCFS4RF7oGjfbkZb0oqep+BfrT+gWEGWG2IowJvIsacPOvzyS1jhNF4MQ4BS59B04Mbovteg==",
-                    "requires": {
-                        "@ethersproject/bignumber": "^5.1.0",
-                        "@ethersproject/bytes": "^5.1.0",
-                        "@ethersproject/keccak256": "^5.1.0",
-                        "@ethersproject/logger": "^5.1.0",
-                        "@ethersproject/rlp": "^5.1.0"
-                    }
-                },
-                "@ethersproject/bignumber": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.1.0.tgz",
-                    "integrity": "sha512-wUvQlhTjPjFXIdLPOuTrFeQmSa6Wvls1bGXQNQWvB/SEn1NsTCE8PmumIEZxmOPjSHl1eV2uyHP5jBm5Cgj92Q==",
-                    "requires": {
-                        "@ethersproject/bytes": "^5.1.0",
-                        "@ethersproject/logger": "^5.1.0",
-                        "bn.js": "^4.4.0"
-                    }
-                },
-                "@ethersproject/bytes": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.1.0.tgz",
-                    "integrity": "sha512-sGTxb+LVjFxJcJeUswAIK6ncgOrh3D8c192iEJd7mLr95V6du119rRfYT/b87WPkZ5I3gRBUYIYXtdgCWACe8g==",
-                    "requires": {
-                        "@ethersproject/logger": "^5.1.0"
-                    }
-                },
-                "@ethersproject/constants": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.1.0.tgz",
-                    "integrity": "sha512-0/SuHrxc8R8k+JiLmJymxHJbojUDWBQqO+b+XFdwaP0jGzqC09YDy/CAlSZB6qHsBifY8X3I89HcK/oMqxRdBw==",
-                    "requires": {
-                        "@ethersproject/bignumber": "^5.1.0"
-                    }
-                },
-                "@ethersproject/hash": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.1.0.tgz",
-                    "integrity": "sha512-fNwry20yLLPpnRRwm3fBL+2ksgO+KMadxM44WJmRIoTKzy4269+rbq9KFoe2LTqq2CXJM2CE70beGaNrpuqflQ==",
-                    "requires": {
-                        "@ethersproject/abstract-signer": "^5.1.0",
-                        "@ethersproject/address": "^5.1.0",
-                        "@ethersproject/bignumber": "^5.1.0",
-                        "@ethersproject/bytes": "^5.1.0",
-                        "@ethersproject/keccak256": "^5.1.0",
-                        "@ethersproject/logger": "^5.1.0",
-                        "@ethersproject/properties": "^5.1.0",
-                        "@ethersproject/strings": "^5.1.0"
-                    }
-                },
-                "@ethersproject/keccak256": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.1.0.tgz",
-                    "integrity": "sha512-vrTB1W6AEYoadww5c9UyVJ2YcSiyIUTNDRccZIgwTmFFoSHwBtcvG1hqy9RzJ1T0bMdATbM9Hfx2mJ6H0i7Hig==",
-                    "requires": {
-                        "@ethersproject/bytes": "^5.1.0",
-                        "js-sha3": "0.5.7"
-                    }
-                },
-                "@ethersproject/logger": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.1.0.tgz",
-                    "integrity": "sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw=="
-                },
-                "@ethersproject/properties": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.1.0.tgz",
-                    "integrity": "sha512-519KKTwgmH42AQL3+GFV3SX6khYEfHsvI6v8HYejlkigSDuqttdgVygFTDsGlofNFchhDwuclrxQnD5B0YLNMg==",
-                    "requires": {
-                        "@ethersproject/logger": "^5.1.0"
-                    }
-                },
-                "@ethersproject/rlp": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.1.0.tgz",
-                    "integrity": "sha512-vDTyHIwNPrecy55gKGZ47eJZhBm8LLBxihzi5ou+zrSvYTpkSTWRcKUlXFDFQVwfWB+P5PGyERAdiDEI76clxw==",
-                    "requires": {
-                        "@ethersproject/bytes": "^5.1.0",
-                        "@ethersproject/logger": "^5.1.0"
-                    }
-                },
-                "@ethersproject/strings": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.1.0.tgz",
-                    "integrity": "sha512-perBZy0RrmmL0ejiFGUOlBVjMsUceqLut3OBP3zP96LhiJWWbS8u1NqQVgN4/Gyrbziuda66DxiQocXhsvx+Sw==",
-                    "requires": {
-                        "@ethersproject/bytes": "^5.1.0",
-                        "@ethersproject/constants": "^5.1.0",
-                        "@ethersproject/logger": "^5.1.0"
-                    }
-                },
                 "@types/node": {
-                    "version": "10.17.56",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
-                    "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
+                    "version": "10.17.60",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+                    "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
                 },
                 "bip39": {
                     "version": "git+https://github.com/bitcoinjs/bip39.git#d8ea080a18b40f301d4e2219a2991cd2417e83c2",
@@ -2291,25 +2085,30 @@
                         "xhr-request-promise": "^0.1.2"
                     }
                 },
-                "js-sha3": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-                    "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+                "lodash": {
+                    "version": "4.17.21",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+                    "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+                },
+                "underscore": {
+                    "version": "1.12.1",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+                    "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
                 },
                 "web3-eth-abi": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.4.tgz",
-                    "integrity": "sha512-PVSLXJ2dzdXsC+R24llIIEOS6S1KhG5qwNznJjJvXZFe3sqgdSe47eNvwUamZtCBjcrdR/HQr+L/FTxqJSf80Q==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.6.tgz",
+                    "integrity": "sha512-Or5cRnZu6WzgScpmbkvC6bfNxR26hqiKK4i8sMPFeTUABQcb/FU3pBj7huBLYbp9dH+P5W79D2MqwbWwjj9DoQ==",
                     "requires": {
                         "@ethersproject/abi": "5.0.7",
-                        "underscore": "1.9.1",
-                        "web3-utils": "1.3.4"
+                        "underscore": "1.12.1",
+                        "web3-utils": "1.3.6"
                     }
                 },
                 "web3-utils": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.4.tgz",
-                    "integrity": "sha512-/vC2v0MaZNpWooJfpRw63u0Y3ag2gNjAWiLtMSL6QQLmCqCy4SQIndMt/vRyx0uMoeGt1YTwSXEcHjUzOhLg0A==",
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.6.tgz",
+                    "integrity": "sha512-hHatFaQpkQgjGVER17gNx8u1qMyaXFZtM0y0XLGH1bzsjMPlkMPLRcYOrZ00rOPfTEuYFOdrpGOqZXVmGrMZRg==",
                     "requires": {
                         "bn.js": "^4.11.9",
                         "eth-lib": "0.2.8",
@@ -2317,7 +2116,7 @@
                         "ethjs-unit": "0.1.6",
                         "number-to-bn": "1.7.0",
                         "randombytes": "^2.1.0",
-                        "underscore": "1.9.1",
+                        "underscore": "1.12.1",
                         "utf8": "3.0.0"
                     },
                     "dependencies": {
@@ -2331,13 +2130,13 @@
             }
         },
         "@celo/wallet-base": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@celo/wallet-base/-/wallet-base-1.1.0.tgz",
-            "integrity": "sha512-dYrWWopiBdf9J47Tgb/DvSvh6cs1mh4RytAlQgAOms/kYLJ7aTVtDvTGFQ01fUn3hyk31AmpahS6ebcf81YvRQ==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@celo/wallet-base/-/wallet-base-1.5.1.tgz",
+            "integrity": "sha512-78playqXi/JEwoyLPyPGjaUnPy/PNNjfqSHRD9IF4uTNxTpaUJJXNWKQSoRF2tFwuLdQxC96hrf63Qzepo5Edg==",
             "requires": {
-                "@celo/base": "1.1.0",
-                "@celo/connect": "1.1.0",
-                "@celo/utils": "1.1.0",
+                "@celo/base": "1.5.1",
+                "@celo/connect": "1.5.1",
+                "@celo/utils": "1.5.1",
                 "@types/debug": "^4.1.5",
                 "@types/ethereumjs-util": "^5.2.0",
                 "bignumber.js": "^9.0.0",
@@ -2347,9 +2146,9 @@
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.3.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
                     "requires": {
                         "ms": "2.1.2"
                     }
@@ -2372,13 +2171,13 @@
             }
         },
         "@celo/wallet-local": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@celo/wallet-local/-/wallet-local-1.1.0.tgz",
-            "integrity": "sha512-SJUUZTUQTYcQdBvG5rzABRWegpeiMMSzK1aaLEgqdzFLZj8moizrlNpBWvUi5qnoESWzhwWI6os4rABRc0wRVQ==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@celo/wallet-local/-/wallet-local-1.5.1.tgz",
+            "integrity": "sha512-StQU8R6SKo+T87LVxMxGG/8WRlruU5dze02Hs8vgEHt3LeYMsrX2k4+FkndANoJF9lhl+XvQrGD4gTaDC4b2ag==",
             "requires": {
-                "@celo/connect": "1.1.0",
-                "@celo/utils": "1.1.0",
-                "@celo/wallet-base": "1.1.0",
+                "@celo/connect": "1.5.1",
+                "@celo/utils": "1.5.1",
+                "@celo/wallet-base": "1.5.1",
                 "@types/ethereumjs-util": "^5.2.0",
                 "eth-lib": "^0.2.8",
                 "ethereumjs-util": "^5.2.0"
@@ -3276,9 +3075,9 @@
             }
         },
         "@keep-network/keep-core": {
-            "version": "1.8.0-pre.6",
-            "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.8.0-pre.6.tgz",
-            "integrity": "sha512-XcVCKx8LU+LWgFT6AVZ9Wz2RLt/m5mJ9ongSUeBZDZ9dy3dhaGMKdJnk12fztUcEIiHfyAINZ91UiS3HPyGQsA==",
+            "version": "1.8.0-dev.5",
+            "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.8.0-dev.5.tgz",
+            "integrity": "sha512-QVkpO5X28Vczj/xHezV0z2UuMw8QFaR3C8x/d6+3adedsL3nCxgveIGTUcXSuYpBqfx0v4/xT+9bIK7BwLkGPw==",
             "requires": {
                 "@openzeppelin/upgrades": "^2.7.2",
                 "openzeppelin-solidity": "2.4.0"
@@ -3292,49 +3091,49 @@
             }
         },
         "@keep-network/keep-ecdsa": {
-            "version": "1.7.0-pre.8",
-            "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.7.0-pre.8.tgz",
-            "integrity": "sha512-SqCGfW0ElBsx3iTTR/8YtHT8H6C0uPIb+P5HqD1ei5Typy+H1WUBVLjUQ6YPNraMtTGmBFmG6LUvrY7WCCTC2A==",
+            "version": "1.9.0-dev.0",
+            "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.9.0-dev.0.tgz",
+            "integrity": "sha512-qkm7pEZYWQmkH5ppQz4azijxwV2jzPeeSQktkHw9Fa2w2GGkgfRuHVl8LYaPimtEYrvx5t2m0LAvmI7zlRQ4Lg==",
             "requires": {
-                "@keep-network/keep-core": "^1.8.0-pre.6",
-                "@keep-network/sortition-pools": ">1.2.0-pre <1.2.0-rc",
+                "@keep-network/keep-core": "1.8.0-dev.5",
+                "@keep-network/sortition-pools": "1.2.0-dev.1",
                 "@openzeppelin/upgrades": "^2.7.2",
                 "openzeppelin-solidity": "2.3.0"
             }
         },
         "@keep-network/sortition-pools": {
-            "version": "1.2.0-pre.6",
-            "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.2.0-pre.6.tgz",
-            "integrity": "sha512-6Tusle8KGZldO8jbFDfxChdgI6hMpTAW4LG+cAkf7jgRR48o6NkUiA7mDoWk/+dlitpHrQpWT1JM4N7aR/4/EQ==",
+            "version": "1.2.0-dev.1",
+            "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.2.0-dev.1.tgz",
+            "integrity": "sha512-CaOsvxNWHgXRFwPThDn3C/LiCwq9pL8ICLXXkysRSLw1Hx69wLnToaXYuwyXeIEy5pGqe5+288DBIqvJ3T4+jA==",
             "requires": {
                 "@openzeppelin/contracts": "^2.4.0"
             }
         },
         "@keep-network/tbtc": {
-            "version": "1.1.2-pre.0",
-            "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.1.2-pre.0.tgz",
-            "integrity": "sha512-zfijjLLcDuK8F/brgxScA/HpESLlJl8Jvr61BC6pIhDzPDrcVaqnG2sioLZurvoJeuXf0VnISSixvWpuNLlPPQ==",
+            "version": "1.1.2-dev.0",
+            "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.1.2-dev.0.tgz",
+            "integrity": "sha512-G/JbDht/IgdX8Ety0i0iUl+kB2J2ofiAmNw+HmN/YUN9BYFhhzQqltPtYjS/krBkWzBYmNJmZBFeX/h+q4EJvA==",
             "requires": {
                 "@celo/contractkit": "^1.0.2",
-                "@keep-network/keep-ecdsa": ">1.7.0-pre <1.7.0-rc",
+                "@keep-network/keep-ecdsa": ">1.9.0-dev <1.9.0-ropsten",
                 "@summa-tx/bitcoin-spv-sol": "^3.1.0",
                 "@summa-tx/relay-sol": "^2.0.2",
                 "openzeppelin-solidity": "2.3.0"
             }
         },
         "@keep-network/tbtc.js": {
-            "version": "0.19.4-pre.0",
-            "resolved": "https://registry.npmjs.org/@keep-network/tbtc.js/-/tbtc.js-0.19.4-pre.0.tgz",
-            "integrity": "sha512-CNoAqabsW0iS7siVa4lJtDLXZKREv+A1igBM5wQlXkKwRZm/ZLAVvzosjcpgZ+VinwxS2vZ0CwjTdrmJXyNoSw==",
+            "version": "0.19.5-dev.0",
+            "resolved": "https://registry.npmjs.org/@keep-network/tbtc.js/-/tbtc.js-0.19.5-dev.0.tgz",
+            "integrity": "sha512-o6zWg7j0Z226auaChZQZRZ+8AWCyhYidip9FVag/6rcpsqdWTQw58osQPinIxsfUJpu8nEzXTrkpTLrt+QEFuA==",
             "requires": {
-                "@keep-network/keep-ecdsa": ">1.7.0-pre <1.7.0-rc",
-                "@keep-network/tbtc": ">1.1.2-pre <1.1.2-rc",
+                "@keep-network/keep-ecdsa": ">1.9.0-dev <1.9.0-ropsten",
+                "@keep-network/tbtc": ">1.1.2-dev <1.1.2-pre",
                 "bcoin": "git+https://github.com/keep-network/bcoin.git#355c21aec91128362668162fe5a309dbc0c59c75",
                 "bcrypto": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.3.0",
                 "bufio": "^1.0.6",
-                "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.0",
+                "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.1",
                 "p-wait-for": "^3.1.0",
-                "web3-utils": "^1.2.8"
+                "web3-utils": "^1.3.0"
             }
         },
         "@ledgerhq/cryptoassets": {
@@ -3591,9 +3390,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.20.7",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-                    "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+                    "version": "12.20.41",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
+                    "integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
                 },
                 "bignumber.js": {
                     "version": "7.2.1",
@@ -3918,44 +3717,40 @@
                     }
                 },
                 "@ledgerhq/devices": {
-                    "version": "5.48.0",
-                    "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.48.0.tgz",
-                    "integrity": "sha512-qIaL0K5Gh9kfePvptB8GGKEHGUAZuJHYmy9eDmIk6RZbgiYJ5njP/u5zQgKxijZArBgssdK/dtxEH4ueTiqkkA==",
+                    "version": "5.51.1",
+                    "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.51.1.tgz",
+                    "integrity": "sha512-4w+P0VkbjzEXC7kv8T1GJ/9AVaP9I6uasMZ/JcdwZBS3qwvKo5A5z9uGhP5c7TvItzcmPb44b5Mw2kT+WjUuAA==",
                     "requires": {
-                        "@ledgerhq/errors": "^5.48.0",
-                        "@ledgerhq/logs": "^5.48.0",
-                        "rxjs": "^6.6.7",
+                        "@ledgerhq/errors": "^5.50.0",
+                        "@ledgerhq/logs": "^5.50.0",
+                        "rxjs": "6",
                         "semver": "^7.3.5"
                     }
                 },
                 "@ledgerhq/errors": {
-                    "version": "5.48.0",
-                    "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.48.0.tgz",
-                    "integrity": "sha512-817t7M0hi7j0xY6uuG0F3kjbkaEP9hHlxfDBpb3EWkTvkg5SgHaDmvHYTjUoE1HhaPypHLjEii7URx2boOfQVA=="
+                    "version": "5.50.0",
+                    "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.50.0.tgz",
+                    "integrity": "sha512-gu6aJ/BHuRlpU7kgVpy2vcYk6atjB4iauP2ymF7Gk0ez0Y/6VSMVSJvubeEQN+IV60+OBK0JgeIZG7OiHaw8ow=="
                 },
                 "@ledgerhq/hw-transport": {
-                    "version": "5.48.0",
-                    "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.48.0.tgz",
-                    "integrity": "sha512-fyy55GDu/UU3fxWqltF7+1PabqMzKxyiWvd1Z89DB+8ZZuz3cq0iN7ey9p4zat2YpIFonVIxKJqyYZZelzsGQA==",
+                    "version": "5.51.1",
+                    "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.51.1.tgz",
+                    "integrity": "sha512-6wDYdbWrw9VwHIcoDnqWBaDFyviyjZWv6H9vz9Vyhe4Qd7TIFmbTl/eWs6hZvtZBza9K8y7zD8ChHwRI4s9tSw==",
                     "requires": {
-                        "@ledgerhq/devices": "^5.48.0",
-                        "@ledgerhq/errors": "^5.48.0",
+                        "@ledgerhq/devices": "^5.51.1",
+                        "@ledgerhq/errors": "^5.50.0",
                         "events": "^3.3.0"
                     }
                 },
                 "@ledgerhq/logs": {
-                    "version": "5.48.0",
-                    "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.48.0.tgz",
-                    "integrity": "sha512-ItOEw1BDsN7q43/uku44izA9y5f6va79KrO5SeYNcojAa3gLn6u02ADLzdHJtuvGEf9DBwCTRPlJmlT7kIaFPQ=="
+                    "version": "5.50.0",
+                    "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.50.0.tgz",
+                    "integrity": "sha512-swKHYCOZUGyVt4ge0u8a7AwNcA//h4nx5wIi0sruGye1IJ5Cva0GyK9L2/WdX+kWVTKp92ZiEo1df31lrWGPgA=="
                 },
                 "@types/node": {
                     "version": "11.11.6",
                     "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
                     "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
-                },
-                "@umpirsky/country-list": {
-                    "version": "git://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
-                    "from": "git://github.com/umpirsky/country-list.git#05fda51"
                 },
                 "bip39": {
                     "version": "3.0.2",
@@ -3982,9 +3777,9 @@
                     },
                     "dependencies": {
                         "@types/node": {
-                            "version": "12.20.7",
-                            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-                            "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+                            "version": "12.20.41",
+                            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
+                            "integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
                         }
                     }
                 },
@@ -4003,9 +3798,9 @@
                     }
                 },
                 "debug": {
-                    "version": "4.3.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
                     "requires": {
                         "ms": "2.1.2"
                     }
@@ -4045,9 +3840,9 @@
                     },
                     "dependencies": {
                         "@types/node": {
-                            "version": "10.17.56",
-                            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
-                            "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
+                            "version": "10.17.60",
+                            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+                            "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
                         },
                         "bn.js": {
                             "version": "4.12.0",
@@ -4104,14 +3899,6 @@
                     "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
                     "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
                 },
-                "rxjs": {
-                    "version": "6.6.7",
-                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-                    "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-                    "requires": {
-                        "tslib": "^1.9.0"
-                    }
-                },
                 "scrypt-js": {
                     "version": "2.0.3",
                     "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
@@ -4146,9 +3933,9 @@
                     },
                     "dependencies": {
                         "@types/node": {
-                            "version": "12.20.7",
-                            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-                            "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+                            "version": "12.20.41",
+                            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
+                            "integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
                         }
                     }
                 },
@@ -4164,9 +3951,9 @@
                     },
                     "dependencies": {
                         "@types/node": {
-                            "version": "10.17.56",
-                            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
-                            "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
+                            "version": "10.17.60",
+                            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+                            "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
                         }
                     }
                 },
@@ -4185,9 +3972,9 @@
                     },
                     "dependencies": {
                         "@types/node": {
-                            "version": "12.20.7",
-                            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-                            "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+                            "version": "12.20.41",
+                            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
+                            "integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
                         }
                     }
                 },
@@ -4376,9 +4163,9 @@
                     },
                     "dependencies": {
                         "@types/node": {
-                            "version": "12.20.7",
-                            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-                            "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+                            "version": "12.20.41",
+                            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
+                            "integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
                         }
                     }
                 },
@@ -4672,14 +4459,17 @@
             "integrity": "sha512-lIxCk6G7AwmUagQ4gIQGxUBnvAq664prFD9nSAz6dgd1XmBXBtZABV/op+QsJsIyaP1GZsf/iXhYKHX3azSRCw=="
         },
         "@types/debug": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
-            "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+            "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+            "requires": {
+                "@types/ms": "*"
+            }
         },
         "@types/elliptic": {
-            "version": "6.4.12",
-            "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.12.tgz",
-            "integrity": "sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==",
+            "version": "6.4.14",
+            "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.14.tgz",
+            "integrity": "sha512-z4OBcDAU0GVwDTuwJzQCiL6188QvZMkvoERgcVjq0/mPM8jCfdwZ3x5zQEVoL9WCAru3aG5wl3Z5Ww5wBWn7ZQ==",
             "requires": {
                 "@types/bn.js": "*"
             }
@@ -4723,9 +4513,9 @@
             }
         },
         "@types/google-libphonenumber": {
-            "version": "7.4.19",
-            "resolved": "https://registry.npmjs.org/@types/google-libphonenumber/-/google-libphonenumber-7.4.19.tgz",
-            "integrity": "sha512-Rm2VhKzu4UofafuTrNTG6fy+385x1PIomnTGGSzOXGbKLpXAhNlUG+7F6UdcIosM5JMvXcJBnwUW/u4qQmt0yg=="
+            "version": "7.4.23",
+            "resolved": "https://registry.npmjs.org/@types/google-libphonenumber/-/google-libphonenumber-7.4.23.tgz",
+            "integrity": "sha512-C3ydakLTQa8HxtYf9ge4q6uT9krDX8smSIxmmW3oACFi5g5vv6T068PRExF7UyWbWpuYiDG8Nm24q2X5XhcZWw=="
         },
         "@types/hdkey": {
             "version": "0.7.1",
@@ -4763,14 +4553,19 @@
             "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
         },
         "@types/lodash": {
-            "version": "4.14.168",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-            "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+            "version": "4.14.178",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
+            "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw=="
         },
         "@types/minimatch": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
             "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+        },
+        "@types/ms": {
+            "version": "0.7.31",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+            "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
         },
         "@types/node": {
             "version": "14.6.0",
@@ -4924,8 +4719,8 @@
             }
         },
         "@umpirsky/country-list": {
-            "version": "git+https://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
-            "from": "git+https://github.com/umpirsky/country-list.git#05fda51"
+            "version": "git://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
+            "from": "git://github.com/umpirsky/country-list.git#05fda51"
         },
         "@web3-js/scrypt-shim": {
             "version": "0.1.0",
@@ -7054,7 +6849,7 @@
                 "bcrypto": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.3.0",
                 "bsert": "git+https://github.com/chjj/bsert.git#semver:~0.0.10",
                 "bufio": "git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6",
-                "loady": "git+https://github.com/chjj/loady.git#b94958b7ee061518f4b85ea6da380e7ee93222d5"
+                "loady": "git+https://github.com/chjj/loady.git#semver:~0.0.1"
             },
             "dependencies": {
                 "bufio": {
@@ -7064,9 +6859,9 @@
             }
         },
         "big-integer": {
-            "version": "1.6.48",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-            "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+            "version": "1.6.51",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
         },
         "big.js": {
             "version": "5.2.2",
@@ -7175,9 +6970,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.20.7",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-                    "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+                    "version": "12.20.41",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
+                    "integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
                 }
             }
         },
@@ -9484,8 +9279,8 @@
             "integrity": "sha512-rM0LWDIstdqfaRUADZetNrL6+zd/0NBmavbMEhBXgc2u/CC1d1GaDyN5hho29fFvBiOVFwrSWZkzmNcZnCEDog=="
         },
         "electrum-client-js": {
-            "version": "git+https://github.com/keep-network/electrum-client-js.git#6bdc216da4228460b6e28706220c70a873f9084d",
-            "from": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.0",
+            "version": "git+https://github.com/keep-network/electrum-client-js.git#8eccf443ca69ab5d81315016057ae9b1ae5818bf",
+            "from": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.1",
             "requires": {
                 "websocket": "^1.0.29"
             }
@@ -9854,7 +9649,7 @@
             "dev": true,
             "requires": {
                 "eslint-config-google": "^0.13.0",
-                "eslint-config-prettier": "^6.10.0",
+                "eslint-config-prettier": "^6.15.0",
                 "eslint-plugin-no-only-tests": "^2.3.1",
                 "eslint-plugin-prettier": "^3.1.2"
             }
@@ -11521,9 +11316,9 @@
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
         },
         "futoin-hkdf": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.3.3.tgz",
-            "integrity": "sha512-oR75fYk3B3X9/B02Y6vusrBKucrpC6VjxhRL+C6B7FwUpuSRHbhBNG3AZbcE/xPyJmEQWsyqUFp3VeNNbA3S7A=="
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.4.3.tgz",
+            "integrity": "sha512-K4MIe2xSVRMYxsA4w0ap5fp1C2hA9StA2Ad1JZHX57VMCdHIRB5BSrd1FhuadTQG9MkjggaTCrw7v5XXFyY3/w=="
         },
         "ganache-core": {
             "version": "2.11.2",
@@ -20667,9 +20462,9 @@
             }
         },
         "google-libphonenumber": {
-            "version": "3.2.19",
-            "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.19.tgz",
-            "integrity": "sha512-zevRvpUuc88wIXa+ijlMprAc8SrldUtYY2vQpfymmxyZ2ksct6gFrGxccpo28+zjvjK51VoSUaDUHS24XYp6dA=="
+            "version": "3.2.26",
+            "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.26.tgz",
+            "integrity": "sha512-qyjAKef1oC2vG81RNy1f5Mk9lYE/H3HC885DCOlFs9ca3QfsqEUnXWOTPXTgEtHnTq1x3vpQgtDbX3Vba/o2ow=="
         },
         "got": {
             "version": "9.6.0",
@@ -23075,12 +22870,44 @@
             }
         },
         "keccak256": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.2.tgz",
-            "integrity": "sha512-f2EncSgmHmmQOkgxZ+/f2VaWTNkFL6f39VIrpoX+p8cEXJVyyCs/3h9GNz/ViHgwchxvv7oG5mjT2Tk4ZqInag==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.6.tgz",
+            "integrity": "sha512-8GLiM01PkdJVGUhR1e6M/AvWnSqYS0HaERI+K/QtStGDGlSTx2B1zTqZk4Zlqu5TxHJNTxWAdP9Y+WI50OApUw==",
             "requires": {
-                "bn.js": "^4.11.8",
-                "keccak": "^3.0.1"
+                "bn.js": "^5.2.0",
+                "buffer": "^6.0.3",
+                "keccak": "^3.0.2"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+                    "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+                },
+                "buffer": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+                    "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+                    "requires": {
+                        "base64-js": "^1.3.1",
+                        "ieee754": "^1.2.1"
+                    }
+                },
+                "ieee754": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+                    "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+                },
+                "keccak": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+                    "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
+                    "requires": {
+                        "node-addon-api": "^2.0.0",
+                        "node-gyp-build": "^4.2.0",
+                        "readable-stream": "^3.6.0"
+                    }
+                }
             }
         },
         "keyv": {
@@ -24164,11 +23991,6 @@
             "version": "4.12.0",
             "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.12.0.tgz",
             "integrity": "sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ=="
-        },
-        "moment": {
-            "version": "2.29.1",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-            "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
         },
         "move-concurrently": {
             "version": "1.0.1",
@@ -29983,9 +29805,9 @@
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
                 },
                 "source-map-support": {
-                    "version": "0.5.19",
-                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-                    "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+                    "version": "0.5.21",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+                    "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
                     "requires": {
                         "buffer-from": "^1.0.0",
                         "source-map": "^0.6.0"
@@ -30085,9 +29907,9 @@
             "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
         },
         "typescript": {
-            "version": "3.9.9",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-            "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
+            "version": "3.9.10",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+            "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
         },
         "typescript-compare": {
             "version": "0.0.2",
@@ -31078,9 +30900,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "10.17.56",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
-                    "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
+                    "version": "10.17.60",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+                    "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
                 }
             }
         },
@@ -31098,9 +30920,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.20.7",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-                    "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+                    "version": "12.20.41",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
+                    "integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
                 },
                 "bn.js": {
                     "version": "4.11.8",
@@ -31314,9 +31136,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "10.17.56",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
-                    "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
+                    "version": "10.17.60",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+                    "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
                 },
                 "elliptic": {
                     "version": "6.3.3",
@@ -31628,9 +31450,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.20.7",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-                    "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+                    "version": "12.20.41",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
+                    "integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
                 },
                 "bn.js": {
                     "version": "4.11.8",
@@ -31879,19 +31701,6 @@
                 "underscore": "1.9.1",
                 "web3-core-helpers": "1.2.2",
                 "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
-            },
-            "dependencies": {
-                "websocket": {
-                    "version": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
-                    "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
-                    "requires": {
-                        "debug": "^2.2.0",
-                        "es5-ext": "^0.10.50",
-                        "nan": "^2.14.0",
-                        "typedarray-to-buffer": "^3.1.5",
-                        "yaeti": "^0.0.6"
-                    }
-                }
             }
         },
         "web3-shh": {
@@ -33023,9 +32832,9 @@
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         },
         "y18n": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-            "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+            "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
         },
         "yaeti": {
             "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.17.6-pre",
     "dependencies": {
         "@0x/subproviders": "^6.0.8",
-        "@keep-network/tbtc.js": ">0.19.4-pre <0.19.4-rc",
+        "@keep-network/tbtc.js": ">0.19.5-dev <0.19.5-ropsten",
         "@ledgerhq/hw-app-eth": "^5.38.0",
         "@ledgerhq/hw-transport-u2f": "^5.11.0",
         "@ledgerhq/web3-subprovider": "^5.11.0",


### PR DESCRIPTION
We recently published first `-dev` suffixed npm package for
`@keep-network/tbtc.js` (`0.19.5-dev.0`).
Now we want to set `tbtc.js` dependency in `tbtc-dapp` to `>0.19.5-dev
<0.19.5-ropsten`. Thanks to this, the NPM workflow will be able to
update the `tbtc.js` dependency to the latest `0.19.5-dev.X` package.