### PR TITLE
Configure git to don't use unauthenticated protocol

### DIFF
--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -61,6 +61,14 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"
+
+      # We need this step because the `@keep-network/tbtc.js` which we update in
+      # next steps has an indirect dependency to `@summa-tx/relay-sol@2.0.2`
+      # package, which downloads one of its sub-dependencies via unathenticated
+      # `git://` protocol. That protocol is no longer supported. Thanks to this
+      # step `https://` is used instead of `git://`.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
       
       - name: Resolve latest tbtc.js
         if: github.event_name != 'workflow_dispatch'

--- a/README.adoc
+++ b/README.adoc
@@ -15,6 +15,18 @@ versions of tbtc.js labeled `-rc*` instead. Clones of the`main` branch of
 this repository will by default use a `-pre*` version of the tbtc.js library;
 this version can be adjusted in the `package.json` file.
 
+*NOTE:* The `tbtc-dapp` package contains an indirect dependency to
+`@summa-tx/relay-sol@2.0.2` package, which downloads one of its sub-dependencies
+via unathenticated `git://` protocol. That protocol is no longer supported by
+GitHub. This means that in certain situations installation of the package or
+update of its dependencies using NPM may result in `The unauthenticated git
+protocol on port 9418 is no longer supported` error. +
+As a workaround, we advise changing Git configuration to use `https://` protocol
+instead of `git://` by executing:
+```
+git config --global url."https://".insteadOf git://
+```
+
 === Run
 
 `npm start` runs the app in the development mode.<br>


### PR DESCRIPTION
We're adding a step that configures git to use `https://` protocol
instead of `git://` when downloading files.
We need this step because the `@keep-network/tbtc.js` which we update in
next steps has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
downloads one of its sub-dependencies via unathenticated `git://`
protocol. That protocol is no longer supported. See
https://github.blog/2021-09-01-improving-git-protocol-security-github/.