### PR TITLE
Cleanup of v1-related GH Actions workflows

### DIFF
--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -1,8 +1,6 @@
 name: Dapp
 
 on:
-  schedule:
-    - cron: '0 0 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
We're no longer adding new functionalities to the `tbtc-dapp` code, as this repository is related to the `v1` of the system and is no longer used in `v2`. There is no need to run the code-checking workflows every night.